### PR TITLE
show table columns automatically when erm file is opened

### DIFF
--- a/src/org/dbflute/erflute/editor/controller/editpart/element/node/TableViewEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/node/TableViewEditPart.java
@@ -46,6 +46,7 @@ import org.eclipse.swt.widgets.Display;
 
 /**
  * @author modified by jflute (originated in ermaster)
+ * @author kajiku
  */
 public abstract class TableViewEditPart extends DiagramWalkerEditPart implements IResizable {
 
@@ -125,6 +126,10 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
             tableFigure.create(tableView.getColor());
             final ERDiagram diagram = this.getDiagram();
             tableFigure.setName(getTableViewName(tableView, diagram));
+            final List childrens = this.getChildren();
+            if (childrens == null || childrens.isEmpty()) {
+                refreshChildren();
+            }
             for (final Object child : this.getChildren()) {
                 if (child instanceof ColumnEditPart) {
                     final ColumnEditPart part = (ColumnEditPart) child;


### PR DESCRIPTION
I fixed show table columns when erm file opens. You don't have to click.