### PR TITLE
"Validate the character of physical name"チェックボックスによって名前を検証するように変更

### DIFF
--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
@@ -11,6 +11,7 @@ import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.colu
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.column.NormalColumn;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.unique_key.CompoundUniqueKey;
 import org.dbflute.erflute.editor.model.diagram_contents.not_element.dictionary.Dictionary;
+import org.dbflute.erflute.editor.model.settings.DiagramSettings;
 
 /**
  * @author modified by jflute (originated in ermaster)
@@ -396,5 +397,9 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
         }
 
         return false;
+    }
+
+    public DiagramSettings getDiagramSettings() {
+        return this.getSourceTableView().getDiagram().getDiagramContents().getSettings();
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERTable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERTable.java
@@ -18,6 +18,7 @@ import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.prop
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.properties.TableViewProperties;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.unique_key.CompoundUniqueKey;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.unique_key.CopyCompoundUniqueKey;
+import org.dbflute.erflute.editor.model.settings.DiagramSettings;
 
 /**
  * @author modified by jflute (originated in ermaster)
@@ -36,8 +37,8 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     private List<CompoundUniqueKey> compoundUniqueKeyList;
 
     public ERTable() {
-        this.indexes = new ArrayList<ERIndex>();
-        this.compoundUniqueKeyList = new ArrayList<CompoundUniqueKey>();
+        this.indexes = new ArrayList<>();
+        this.compoundUniqueKeyList = new ArrayList<>();
     }
 
     public NormalColumn getAutoIncrementColumn() {
@@ -66,7 +67,7 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
 
         super.copyTableViewData(to);
 
-        final List<ERIndex> indexes = new ArrayList<ERIndex>();
+        final List<ERIndex> indexes = new ArrayList<>();
 
         for (final ERIndex fromIndex : this.getIndexes()) {
             indexes.add(new CopyIndex(to, fromIndex, to.getColumns()));
@@ -74,7 +75,7 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
 
         to.setIndexes(indexes);
 
-        final List<CompoundUniqueKey> complexUniqueKeyList = new ArrayList<CompoundUniqueKey>();
+        final List<CompoundUniqueKey> complexUniqueKeyList = new ArrayList<>();
 
         for (final CompoundUniqueKey complexUniqueKey : this.getCompoundUniqueKeyList()) {
             complexUniqueKeyList.add(new CopyCompoundUniqueKey(complexUniqueKey, to.getColumns()));
@@ -97,7 +98,7 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
 
         super.restructureData(to);
 
-        final List<ERIndex> indexes = new ArrayList<ERIndex>();
+        final List<ERIndex> indexes = new ArrayList<>();
 
         for (final ERIndex fromIndex : this.getIndexes()) {
             final CopyIndex copyIndex = (CopyIndex) fromIndex;
@@ -106,7 +107,7 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
         }
         table.setIndexes(indexes);
 
-        final List<CompoundUniqueKey> complexUniqueKeyList = new ArrayList<CompoundUniqueKey>();
+        final List<CompoundUniqueKey> complexUniqueKeyList = new ArrayList<>();
 
         for (final CompoundUniqueKey complexUniqueKey : this.getCompoundUniqueKeyList()) {
             final CopyCompoundUniqueKey copyComplexUniqueKey = (CopyCompoundUniqueKey) complexUniqueKey;
@@ -137,7 +138,7 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     }
 
     public List<NormalColumn> getPrimaryKeys() {
-        final List<NormalColumn> primaryKeys = new ArrayList<NormalColumn>();
+        final List<NormalColumn> primaryKeys = new ArrayList<>();
 
         for (final ERColumn column : this.columns) {
             if (column instanceof NormalColumn) {
@@ -322,5 +323,9 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
 
     public void setOption(String option) {
         this.option = option;
+    }
+
+    public DiagramSettings getDiagramSettings() {
+        return getDiagram().getDiagramContents().getSettings();
     }
 }

--- a/src/org/dbflute/erflute/editor/view/dialog/column/real/ColumnDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/column/real/ColumnDialog.java
@@ -279,7 +279,7 @@ public class ColumnDialog extends AbstractRealColumnDialog {
             }
         }
         final String uniqueKeyName = uniqueKeyNameText.getText().trim();
-        if (!Check.isAlphabet(uniqueKeyName)) {
+        if (table.getDiagram().getDiagramContents().getSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
             return "error.unique.key.name.not.alphabet";
         }
         final String physicalName = physicalNameText.getText().trim();

--- a/src/org/dbflute/erflute/editor/view/dialog/column/real/ColumnDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/column/real/ColumnDialog.java
@@ -279,7 +279,7 @@ public class ColumnDialog extends AbstractRealColumnDialog {
             }
         }
         final String uniqueKeyName = uniqueKeyNameText.getText().trim();
-        if (table.getDiagram().getDiagramContents().getSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
+        if (table.getDiagramSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
             return "error.unique.key.name.not.alphabet";
         }
         final String physicalName = physicalNameText.getText().trim();

--- a/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
@@ -292,7 +292,7 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
         if (Srl.is_Null_or_TrimmedEmpty(foreignKeyName)) {
             return "Input foreign key name e.g. FK_XXX";
         }
-        if (!Check.isAlphabet(foreignKeyName)) {
+        if (source.getDiagramSettings().isValidatePhysicalName() && !Check.isAlphabet(foreignKeyName)) {
             return "error.foreign.key.name.not.alphabet";
         }
         final ERDiagram diagram = target.getDiagram();

--- a/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipDialog.java
@@ -306,7 +306,7 @@ public class RelationshipDialog extends AbstractDialog {
     protected String doValidate() {
         final String foreignKeyName = foreignKeyNameText.getText().trim(); // not required for compatible
         if (Srl.is_NotNull_and_NotTrimmedEmpty(foreignKeyName)) {
-            if (!Check.isAlphabet(foreignKeyName)) {
+            if (relationship.getDiagramSettings().isValidatePhysicalName() && !Check.isAlphabet(foreignKeyName)) {
                 return "error.foreign.key.name.not.alphabet";
             }
             final ERDiagram diagram = relationship.getTargetTableView().getDiagram();

--- a/src/org/dbflute/erflute/editor/view/dialog/table/tab/CompoundUniqueKeyTabWrapper.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/table/tab/CompoundUniqueKeyTabWrapper.java
@@ -213,7 +213,7 @@ public class CompoundUniqueKeyTabWrapper extends ValidatableTabWrapper {
             Activator.showErrorDialog("The constraint name for unique key is required: Change 'XXX' part: " + uniqueKeyName);
             return false;
         }
-        if (table.getDiagram().getDiagramContents().getSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
+        if (table.getDiagramSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
             Activator.showErrorDialog("error.unique.key.name.not.alphabet");
             return false;
         }
@@ -272,7 +272,7 @@ public class CompoundUniqueKeyTabWrapper extends ValidatableTabWrapper {
         //    throw new InputException("error.unique.key.name.empty");
         //}
         if (Srl.is_NotNull_and_NotTrimmedEmpty(uniqueKeyName)) {
-            if (table.getDiagram().getDiagramContents().getSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
+            if (table.getDiagramSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
                 throw new InputException("error.unique.key.name.not.alphabet");
             }
             final List<ERTable> tableList = table.getDiagram().getDiagramContents().getDiagramWalkers().getTableSet().getList();

--- a/src/org/dbflute/erflute/editor/view/dialog/table/tab/CompoundUniqueKeyTabWrapper.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/table/tab/CompoundUniqueKeyTabWrapper.java
@@ -213,7 +213,7 @@ public class CompoundUniqueKeyTabWrapper extends ValidatableTabWrapper {
             Activator.showErrorDialog("The constraint name for unique key is required: Change 'XXX' part: " + uniqueKeyName);
             return false;
         }
-        if (!Check.isAlphabet(uniqueKeyName)) {
+        if (table.getDiagram().getDiagramContents().getSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
             Activator.showErrorDialog("error.unique.key.name.not.alphabet");
             return false;
         }
@@ -272,7 +272,7 @@ public class CompoundUniqueKeyTabWrapper extends ValidatableTabWrapper {
         //    throw new InputException("error.unique.key.name.empty");
         //}
         if (Srl.is_NotNull_and_NotTrimmedEmpty(uniqueKeyName)) {
-            if (!Check.isAlphabet(uniqueKeyName)) {
+            if (table.getDiagram().getDiagramContents().getSettings().isValidatePhysicalName() && !Check.isAlphabet(uniqueKeyName)) {
                 throw new InputException("error.unique.key.name.not.alphabet");
             }
             final List<ERTable> tableList = table.getDiagram().getDiagramContents().getDiagramWalkers().getTableSet().getList();


### PR DESCRIPTION
右クリックメニューの"Diagram Settings> Option> Validate the character of physical name"にチェックが入っている場合のみ、"Table Information"の"Compound Unique Key"タブにあるユニークキー名の検証をするように変更しました。

"Relation information"の"Constraint name"も同様です。

テーブル名に日本語名を使うため、変更しました。
"Validate the character of physical name"に、ユニークキー名や外部キー名のチェックが連動しないと、テーブルを保存できないためです。