### PR TITLE
Fixed problem in virtual diagram. etc

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -386,7 +386,7 @@ org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constan
 org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration=do not insert
 org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation=do not insert
 org.eclipse.jdt.core.formatter.join_lines_in_comments=true
-org.eclipse.jdt.core.formatter.join_wrapped_lines=true
+org.eclipse.jdt.core.formatter.join_wrapped_lines=false
 org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line=false
 org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line=false
 org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line=false

--- a/plugin.properties
+++ b/plugin.properties
@@ -1,3 +1,3 @@
 plugin.name=ERFlute
-wizard.new.title=new ERDiagram(); // for ERFlute
+wizard.new.title=ERFlute
 preference.page.jdbc=JDBC Driver

--- a/resources/deleted_erflute_messages_ja.properties
+++ b/resources/deleted_erflute_messages_ja.properties
@@ -306,7 +306,6 @@ label.without.oids=Widhout OIDs
 label.word=\u5358\u8a9e
 label.ermodel=\u30c0\u30a4\u30a2\u30b0\u30e9\u30e0
 
-
 label.button.add=\u8ffd\u52a0
 label.button.add.group.to.table=\u3000\u3000\u30b0\u30eb\u30fc\u30d7\u9805\u76ee\u3092\u30c6\u30fc\u30d6\u30eb\u306b\u8ffd\u52a0\u3059\u308b\u3000\u3000
 label.button.add.group.to.view=\u3000\u3000\u30b0\u30eb\u30fc\u30d7\u9805\u76ee\u3092\u30d3\u30e5\u30fc\u306b\u8ffd\u52a0\u3059\u308b\u3000\u3000
@@ -337,7 +336,6 @@ new.table.physical.name=NEW_TABLE
 new.table.logical.name=\u65b0\u898f\u30c6\u30fc\u30d6\u30eb
 new.view.physical.name=NEW_VIEW
 new.view.logical.name=\u65b0\u898f\u30d3\u30e5\u30fc
-
 
 wizard.new.diagram.title=\u65b0\u898fER\u56f3
 wizard.new.diagram.message=\u65b0\u898fER\u56f3\u3092\u4f5c\u6210\u3057\u307e\u3059\u3002

--- a/resources/erflute_messages.properties
+++ b/resources/erflute_messages.properties
@@ -302,7 +302,6 @@ label.view.name=View Name
 label.without.oids=Widhout OIDs
 label.word=Word
 
-
 label.button.add=Add
 label.button.add.group.to.table=Add the group item to the table
 label.button.add.group.to.view=Add the group item to the view
@@ -628,7 +627,6 @@ error.view.physical.name.already.exists=The 'Physical View Name' already exists 
 error.view.sql.empty=Please input the sql.
 error.write.file=The error occurred while writing the file.
 error.wrong.template=Template file is wrong format.
-
 
 search.result.row.type.1 = Foreign Key Constraint
 search.result.row.name.1 = Constraint Name

--- a/src/org/dbflute/erflute/db/DBManagerBase.java
+++ b/src/org/dbflute/erflute/db/DBManagerBase.java
@@ -16,6 +16,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.dbflute.erflute.core.util.Check;
 import org.dbflute.erflute.editor.model.settings.JDBCDriverSetting;
 import org.dbflute.erflute.preference.PreferenceInitializer;
 import org.dbflute.erflute.preference.jdbc.JDBCPathDialog;
@@ -54,6 +55,9 @@ public abstract class DBManagerBase implements DBManager {
                 return clazz;
             } catch (final ClassNotFoundException e) {
                 path = PreferenceInitializer.getJDBCDriverPath(this.getId(), driverClassName);
+                if (Check.isEmpty(path)) {
+                    throw new IllegalStateException(String.format("JDBC Driver Class \"%s\" is not found", driverClassName));
+                }
                 final ClassLoader loader = this.getClassLoader(path);
                 @SuppressWarnings("unchecked")
                 final Class<Driver> clazz = (Class<Driver>) loader.loadClass(driverClassName);

--- a/src/org/dbflute/erflute/db/DBManagerBase.java
+++ b/src/org/dbflute/erflute/db/DBManagerBase.java
@@ -56,7 +56,9 @@ public abstract class DBManagerBase implements DBManager {
             } catch (final ClassNotFoundException e) {
                 path = PreferenceInitializer.getJDBCDriverPath(this.getId(), driverClassName);
                 if (Check.isEmpty(path)) {
-                    throw new IllegalStateException(String.format("JDBC Driver Class \"%s\" is not found", driverClassName));
+                    throw new IllegalStateException(
+                            String.format("JDBC Driver Class \"%s\" is not found.\rIs \"Preferences> ERFlute> JDBC Driver\" set correctly?",
+                                    driverClassName));
                 }
                 final ClassLoader loader = this.getClassLoader(path);
                 @SuppressWarnings("unchecked")

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -339,6 +339,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
             diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram(), editor.getVirtualDiagram().getName());
             ERModelUtil.refreshDiagram(diagram);
         } else { // main editor
+            selectedEditor.clearSelection();
             diagram.setCurrentVirtualDiagram(null, null);
             diagram.changeAll();
         }

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -120,7 +120,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         if (modelName != null) {
             try {
                 final ERVirtualDiagram vdiagram = diagram.getDiagramContents().getVirtualDiagramSet().getVdiagramByName(modelName);
-                diagram.setCurrentVirtualDiagram(vdiagram, vdiagram.getName());
+                diagram.setCurrentVirtualDiagram(vdiagram);
                 final VirtualDiagramEditor modelEditor =
                         new VirtualDiagramEditor(diagram, vdiagram, editPartFactory, zoomComboContributionItem, outlinePage);
                 final int pageNo = addPage(modelEditor, getEditorInput()); // as view
@@ -336,11 +336,11 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         selectedEditor.changeCategory();
         if (selectedEditor instanceof VirtualDiagramEditor) { // sub editor
             final VirtualDiagramEditor editor = (VirtualDiagramEditor) selectedEditor;
-            diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram(), editor.getVirtualDiagram().getName());
+            diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram());
             ERModelUtil.refreshDiagram(diagram);
         } else { // main editor
             selectedEditor.clearSelection();
-            diagram.setCurrentVirtualDiagram(null, null);
+            diagram.setCurrentVirtualDiagram(null);
             diagram.changeAll();
         }
     }
@@ -415,7 +415,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
             final VirtualDiagramEditor diagramEditor = (VirtualDiagramEditor) getEditor(1);
             setPageText(1, Format.null2blank(model.getName()));
             diagramEditor.setContents(model);
-            model.getDiagram().setCurrentVirtualDiagram(model, model.getName());
+            model.getDiagram().setCurrentVirtualDiagram(model);
             setActiveEditor(diagramEditor);
         }
     }

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -91,8 +91,6 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         if (diagram.getCurrentVirtualDiagram() == null) {
             final MainDiagramEditor diagramEditor = (MainDiagramEditor) getActiveEditor();
             diagramEditor.getGraphicalViewer().setContents(diagram);
-            // TODO コミット：4d16e401721d04f29b437c3c1c15fe569ebf1c5に関連
-            diagramEditor.changeCategory();
         }
     }
 
@@ -338,12 +336,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
             editor.removeSelection();
         }
         final MainDiagramEditor selectedEditor = (MainDiagramEditor) getActiveEditor();
-        // TODO バグ修正のためコメント化(コミット：4d16e401721d04f29b437c3c1c15fe569ebf1c5)
-        // "アウトラインで仮想ダイアグラムをダブルクリックで開く→開いたエディタクリック→別の仮想ダイアグラムをダブルクリックで開く"操作をする。
-        // するとアウトライン上で、ダブルクリックした仮想ダイアグラムでなく、エディタクリック時の仮想ダイアグラムが選択されている。
-        // この問題を修正するため、以下"selectedEditor.changeCategory();"をコメント化した。
-        // 何か別の問題が発生したらコメントを外すこと。
-        //selectedEditor.changeCategory();
+        selectedEditor.changeCategory();
         if (selectedEditor instanceof VirtualDiagramEditor) { // sub editor
             final VirtualDiagramEditor editor = (VirtualDiagramEditor) selectedEditor;
             this.diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram(), editor.getVirtualDiagram().getName());

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -11,6 +11,7 @@ import org.dbflute.erflute.db.DBManagerFactory;
 import org.dbflute.erflute.editor.controller.command.category.ChangeCategoryNameCommand;
 import org.dbflute.erflute.editor.controller.editpart.element.ERDiagramEditPartFactory;
 import org.dbflute.erflute.editor.model.ERDiagram;
+import org.dbflute.erflute.editor.model.ERModelUtil;
 import org.dbflute.erflute.editor.model.dbexport.ddl.validator.ValidateResult;
 import org.dbflute.erflute.editor.model.dbexport.ddl.validator.Validator;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.category.Category;
@@ -339,6 +340,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         if (selectedEditor instanceof VirtualDiagramEditor) { // sub editor
             final VirtualDiagramEditor editor = (VirtualDiagramEditor) selectedEditor;
             this.diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram(), editor.getVirtualDiagram().getName());
+            ERModelUtil.refreshDiagram(diagram);
         } else { // main editor
             this.diagram.setCurrentVirtualDiagram(null, null);
             this.diagram.changeAll();

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -91,6 +91,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         if (diagram.getCurrentVirtualDiagram() == null) {
             final MainDiagramEditor diagramEditor = (MainDiagramEditor) getActiveEditor();
             diagramEditor.getGraphicalViewer().setContents(diagram);
+            diagramEditor.addSelection();
         }
     }
 
@@ -331,10 +332,6 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
     @Override
     protected void pageChange(int newPageIndex) {
         super.pageChange(newPageIndex);
-        for (int i = 0; i < getPageCount(); i++) {
-            final MainDiagramEditor editor = (MainDiagramEditor) getEditor(i);
-            editor.removeSelection();
-        }
         final MainDiagramEditor selectedEditor = (MainDiagramEditor) getActiveEditor();
         selectedEditor.changeCategory();
         if (selectedEditor instanceof VirtualDiagramEditor) { // sub editor

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -75,9 +75,9 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
     protected void createPages() {
         prepareDiagram();
         editPartFactory = new ERDiagramEditPartFactory();
-        outlinePage = new ERDiagramOutlinePage(this.diagram);
+        outlinePage = new ERDiagramOutlinePage(diagram);
         try {
-            zoomComboContributionItem = new ZoomComboContributionItem(this.getSite().getPage());
+            zoomComboContributionItem = new ZoomComboContributionItem(getSite().getPage());
             final MainDiagramEditor editor = new MainDiagramEditor(diagram, editPartFactory, zoomComboContributionItem, outlinePage);
             final int index = addPage(editor, getEditorInput()); // as main
             setPageText(index, "Main Diagram");
@@ -138,14 +138,14 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         } else {
             setActivePage(0);
         }
-        final MainDiagramEditor activeEditor = (MainDiagramEditor) this.getActiveEditor();
+        final MainDiagramEditor activeEditor = (MainDiagramEditor) getActiveEditor();
         final ZoomManager zoomManager = (ZoomManager) activeEditor.getAdapter(ZoomManager.class);
-        zoomManager.setZoom(this.diagram.getZoom());
-        activeEditor.setLocation(this.diagram.getX(), this.diagram.getY());
+        zoomManager.setZoom(diagram.getZoom());
+        activeEditor.setLocation(diagram.getX(), diagram.getY());
     }
 
     private void addMouseListenerToTabFolder() {
-        final CTabFolder tabFolder = (CTabFolder) this.getContainer();
+        final CTabFolder tabFolder = (CTabFolder) getContainer();
         tabFolder.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseDoubleClick(MouseEvent mouseevent) {
@@ -165,9 +165,9 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
     }
 
     private void validate() {
-        final IFile file = ((IFileEditorInput) this.getEditorInput()).getFile();
+        final IFile file = ((IFileEditorInput) getEditorInput()).getFile();
 
-        if (this.diagram.getDiagramContents().getSettings().isSuspendValidator()) {
+        if (diagram.getDiagramContents().getSettings().isSuspendValidator()) {
             try {
                 file.deleteMarkers(null, true, IResource.DEPTH_INFINITE);
             } catch (final CoreException e) {
@@ -211,33 +211,33 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
 
     private List<ValidateResult> validateTodo() {
         final List<ValidateResult> resultList = new ArrayList<>();
-        for (final ERTable table : this.diagram.getDiagramContents().getDiagramWalkers().getTableSet()) {
+        for (final ERTable table : diagram.getDiagramContents().getDiagramWalkers().getTableSet()) {
             String description = table.getDescription();
-            resultList.addAll(this.createTodo(description, table.getLogicalName(), table));
+            resultList.addAll(createTodo(description, table.getLogicalName(), table));
             for (final NormalColumn column : table.getNormalColumns()) {
                 description = column.getDescription();
-                resultList.addAll(this.createTodo(description, table.getLogicalName(), table));
+                resultList.addAll(createTodo(description, table.getLogicalName(), table));
             }
             for (final ERIndex index : table.getIndexes()) {
                 description = index.getDescription();
-                resultList.addAll(this.createTodo(description, index.getName(), index));
+                resultList.addAll(createTodo(description, index.getName(), index));
             }
         }
-        for (final ERView view : this.diagram.getDiagramContents().getDiagramWalkers().getViewSet().getList()) {
+        for (final ERView view : diagram.getDiagramContents().getDiagramWalkers().getViewSet().getList()) {
             String description = view.getDescription();
-            resultList.addAll(this.createTodo(description, view.getName(), view));
+            resultList.addAll(createTodo(description, view.getName(), view));
             for (final NormalColumn column : view.getNormalColumns()) {
                 description = column.getDescription();
-                resultList.addAll(this.createTodo(description, view.getLogicalName(), view));
+                resultList.addAll(createTodo(description, view.getLogicalName(), view));
             }
         }
-        for (final Trigger trigger : this.diagram.getDiagramContents().getTriggerSet().getTriggerList()) {
+        for (final Trigger trigger : diagram.getDiagramContents().getTriggerSet().getTriggerList()) {
             final String description = trigger.getDescription();
-            resultList.addAll(this.createTodo(description, trigger.getName(), trigger));
+            resultList.addAll(createTodo(description, trigger.getName(), trigger));
         }
-        for (final Sequence sequence : this.diagram.getDiagramContents().getSequenceSet().getSequenceList()) {
+        for (final Sequence sequence : diagram.getDiagramContents().getSequenceSet().getSequenceList()) {
             final String description = sequence.getDescription();
-            resultList.addAll(this.createTodo(description, sequence.getName(), sequence));
+            resultList.addAll(createTodo(description, sequence.getName(), sequence));
         }
         return resultList;
     }
@@ -268,7 +268,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
     @Override
     protected Composite createPageContainer(Composite parent) {
         try {
-            final IWorkbenchPage page = this.getSite().getWorkbenchWindow().getActivePage();
+            final IWorkbenchPage page = getSite().getWorkbenchWindow().getActivePage();
             if (page != null) {
                 page.showView(IPageLayout.ID_OUTLINE);
             }
@@ -284,18 +284,18 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
     @Override
     public void doSave(IProgressMonitor monitor) {
         monitor.setTaskName("save initialize...");
-        final ZoomManager zoomManager = (ZoomManager) this.getActiveEditor().getAdapter(ZoomManager.class);
+        final ZoomManager zoomManager = (ZoomManager) getActiveEditor().getAdapter(ZoomManager.class);
         final double zoom = zoomManager.getZoom();
-        this.diagram.setZoom(zoom);
+        diagram.setZoom(zoom);
 
-        final MainDiagramEditor activeEditor = (MainDiagramEditor) this.getActiveEditor();
+        final MainDiagramEditor activeEditor = (MainDiagramEditor) getActiveEditor();
         final Point location = activeEditor.getLocation();
-        this.diagram.setLocation(location.x, location.y);
+        diagram.setLocation(location.x, location.y);
         final Persistent persistent = Persistent.getInstance();
-        final IFile file = ((IFileEditorInput) this.getEditorInput()).getFile();
+        final IFile file = ((IFileEditorInput) getEditorInput()).getFile();
         try {
             monitor.setTaskName("create stream...");
-            final InputStream source = persistent.write(this.diagram);
+            final InputStream source = persistent.write(diagram);
             if (!file.exists()) {
                 file.create(source, true, monitor);
             } else {
@@ -304,9 +304,9 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         } catch (final Exception e) {
             Activator.showExceptionDialog(e);
         }
-        monitor.beginTask("saving...", this.getPageCount());
-        for (int i = 0; i < this.getPageCount(); i++) {
-            final IEditorPart editor = this.getEditor(i);
+        monitor.beginTask("saving...", getPageCount());
+        for (int i = 0; i < getPageCount(); i++) {
+            final IEditorPart editor = getEditor(i);
             editor.doSave(monitor);
             monitor.worked(i + 1);
         }
@@ -336,11 +336,11 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         selectedEditor.changeCategory();
         if (selectedEditor instanceof VirtualDiagramEditor) { // sub editor
             final VirtualDiagramEditor editor = (VirtualDiagramEditor) selectedEditor;
-            this.diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram(), editor.getVirtualDiagram().getName());
+            diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram(), editor.getVirtualDiagram().getName());
             ERModelUtil.refreshDiagram(diagram);
         } else { // main editor
-            this.diagram.setCurrentVirtualDiagram(null, null);
-            this.diagram.changeAll();
+            diagram.setCurrentVirtualDiagram(null, null);
+            diagram.changeAll();
         }
     }
 
@@ -367,7 +367,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
 
     @Override
     public void dispose() {
-        this.elementStateListener.disposeDocumentProvider();
+        elementStateListener.disposeDocumentProvider();
         super.dispose();
     }
 
@@ -377,19 +377,19 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
     }
 
     public void setCurrentCategoryPageName() {
-        final Category category = this.getCurrentPageCategory();
-        this.setPageText(this.getActivePage(), Format.null2blank(category.getName()));
+        final Category category = getCurrentPageCategory();
+        setPageText(getActivePage(), Format.null2blank(category.getName()));
     }
 
     private void execute(Command command) {
-        final MainDiagramEditor selectedEditor = (MainDiagramEditor) this.getActiveEditor();
+        final MainDiagramEditor selectedEditor = (MainDiagramEditor) getActiveEditor();
         selectedEditor.getGraphicalViewer().getEditDomain().getCommandStack().execute(command);
     }
 
     @Override
     public Object getAdapter(@SuppressWarnings("rawtypes") Class type) {
         if (type == ERDiagram.class) {
-            return this.diagram;
+            return diagram;
         }
         return super.getAdapter(type);
     }
@@ -403,7 +403,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
     public void setCurrentErmodel(ERVirtualDiagram model) {
         if (getPageCount() == 1) {
             final VirtualDiagramEditor diagramEditor =
-                    new VirtualDiagramEditor(this.diagram, model, getEditPartFactory(), getZoomComboContributionItem(), getOutlinePage());
+                    new VirtualDiagramEditor(diagram, model, getEditPartFactory(), getZoomComboContributionItem(), getOutlinePage());
             try {
                 addPage(diagramEditor, getEditorInput(), model.getName());
                 setActiveEditor(diagramEditor);
@@ -436,7 +436,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
 
     @Override
     public boolean isDirty() {
-        return this.dirty || super.isDirty();
+        return dirty || super.isDirty();
     }
 
     public void setPageText(String text) {

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -300,6 +300,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
             } else {
                 file.setContents(source, true, false, monitor);
             }
+            setDirty(false);
         } catch (final Exception e) {
             Activator.showExceptionDialog(e);
         }

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -91,6 +91,8 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         if (diagram.getCurrentVirtualDiagram() == null) {
             final MainDiagramEditor diagramEditor = (MainDiagramEditor) getActiveEditor();
             diagramEditor.getGraphicalViewer().setContents(diagram);
+            // TODO コミット：4d16e401721d04f29b437c3c1c15fe569ebf1c5に関連
+            diagramEditor.changeCategory();
         }
     }
 
@@ -336,7 +338,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
             editor.removeSelection();
         }
         final MainDiagramEditor selectedEditor = (MainDiagramEditor) getActiveEditor();
-        // TODO バグ修正のためコメント化
+        // TODO バグ修正のためコメント化(コミット：4d16e401721d04f29b437c3c1c15fe569ebf1c5)
         // "アウトラインで仮想ダイアグラムをダブルクリックで開く→開いたエディタクリック→別の仮想ダイアグラムをダブルクリックで開く"操作をする。
         // するとアウトライン上で、ダブルクリックした仮想ダイアグラムでなく、エディタクリック時の仮想ダイアグラムが選択されている。
         // この問題を修正するため、以下"selectedEditor.changeCategory();"をコメント化した。

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -300,7 +300,6 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
             } else {
                 file.setContents(source, true, false, monitor);
             }
-            setDirty(false);
         } catch (final Exception e) {
             Activator.showExceptionDialog(e);
         }
@@ -443,7 +442,7 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         return this.dirty || super.isDirty();
     }
 
-    public void setDirty(boolean dirty) {
-        this.dirty = dirty;
+    public void setPageText(String text) {
+        setPageText(1, text);
     }
 }

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -336,7 +336,12 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
             editor.removeSelection();
         }
         final MainDiagramEditor selectedEditor = (MainDiagramEditor) getActiveEditor();
-        selectedEditor.changeCategory();
+        // TODO バグ修正のためコメント化
+        // "アウトラインで仮想ダイアグラムをダブルクリックで開く→開いたエディタクリック→別の仮想ダイアグラムをダブルクリックで開く"操作をする。
+        // するとアウトライン上で、ダブルクリックした仮想ダイアグラムでなく、エディタクリック時の仮想ダイアグラムが選択されている。
+        // この問題を修正するため、以下"selectedEditor.changeCategory();"をコメント化した。
+        // 何か別の問題が発生したらコメントを外すこと。
+        //selectedEditor.changeCategory();
         if (selectedEditor instanceof VirtualDiagramEditor) { // sub editor
             final VirtualDiagramEditor editor = (VirtualDiagramEditor) selectedEditor;
             this.diagram.setCurrentVirtualDiagram(editor.getVirtualDiagram(), editor.getVirtualDiagram().getName());

--- a/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
+++ b/src/org/dbflute/erflute/editor/ERFluteMultiPageEditor.java
@@ -89,9 +89,9 @@ public class ERFluteMultiPageEditor extends MultiPageEditorPart {
         addMouseListenerToTabFolder();
         validate();
         if (diagram.getCurrentVirtualDiagram() == null) {
-            final MainDiagramEditor diagramEditor = (MainDiagramEditor) getActiveEditor();
-            diagramEditor.getGraphicalViewer().setContents(diagram);
-            diagramEditor.addSelection();
+            final MainDiagramEditor editor = (MainDiagramEditor) getActiveEditor();
+            editor.getGraphicalViewer().setContents(diagram);
+            editor.addSelection();
         }
     }
 

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -196,8 +196,8 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
 
         prepareERDiagramPopupMenu(viewer);
 
-        this.outlineMenuMgr = new ERDiagramOutlinePopupMenuManager(diagram, getActionRegistry(), outlinePage.getOutlineActionRegistory(),
-                outlinePage.getViewer());
+        this.outlineMenuMgr = new ERDiagramOutlinePopupMenuManager(
+                diagram, getActionRegistry(), outlinePage.getOutlineActionRegistory(), outlinePage.getViewer());
         outlinePage.setContextMenu(outlineMenuMgr);
         this.gotoMaker = new ERDiagramGotoMarker(this);
     }
@@ -220,19 +220,19 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
             return ((ScalableFreeformRootEditPart) getGraphicalViewer().getRootEditPart()).getZoomManager();
         }
         if (type == IContentOutlinePage.class) {
-            return this.outlinePage;
+            return outlinePage;
         }
         if (type == IGotoMarker.class) {
-            return this.gotoMaker;
+            return gotoMaker;
         }
         if (type == IPropertySheetPage.class) {
-            return this.propertySheetPage;
+            return propertySheetPage;
         }
         return super.getAdapter(type);
     }
 
     public void changeCategory() {
-        this.outlinePage.setCategory(this.getEditDomain(), this.getGraphicalViewer(), this.getActionRegistry());
+        outlinePage.setCategory(getEditDomain(), getGraphicalViewer(), getActionRegistry());
     }
 
     @Override
@@ -244,7 +244,7 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
     }
 
     public void addSelection() {
-        this.getSelectionSynchronizer().addViewer(this.outlinePage.getViewer());
+        getSelectionSynchronizer().addViewer(outlinePage.getViewer());
     }
 
     // TODO jflute ermaster: 何度も呼ばれている疑惑、増えていく増えていく
@@ -292,13 +292,13 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
             }
             registry.registerAction(action);
         }
-        this.addKeyHandler(registry.getAction(SearchAction.ID));
-        this.addKeyHandler(registry.getAction(ERDiagramQuickOutlineAction.ID));
+        addKeyHandler(registry.getAction(SearchAction.ID));
+        addKeyHandler(registry.getAction(ERDiagramQuickOutlineAction.ID));
     }
 
     @SuppressWarnings("unchecked")
     protected void initViewerAction(GraphicalViewer viewer) {
-        final ScalableFreeformRootEditPart rootEditPart = new PagableFreeformRootEditPart(this.diagram);
+        final ScalableFreeformRootEditPart rootEditPart = new PagableFreeformRootEditPart(diagram);
         viewer.setRootEditPart(rootEditPart);
 
         final ZoomManager manager = rootEditPart.getZoomManager();
@@ -316,33 +316,33 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
         final ZoomOutAction zoomOutAction = new ZoomOutAction(manager);
         final ZoomAdjustAction zoomAdjustAction = new ZoomAdjustAction(manager);
 
-        this.getActionRegistry().registerAction(zoomInAction);
-        this.getActionRegistry().registerAction(zoomOutAction);
-        this.getActionRegistry().registerAction(zoomAdjustAction);
+        getActionRegistry().registerAction(zoomInAction);
+        getActionRegistry().registerAction(zoomOutAction);
+        getActionRegistry().registerAction(zoomAdjustAction);
 
-        this.addKeyHandler(zoomInAction);
-        this.addKeyHandler(zoomOutAction);
+        addKeyHandler(zoomInAction);
+        addKeyHandler(zoomOutAction);
 
         final IFigure gridLayer = rootEditPart.getLayer(LayerConstants.GRID_LAYER);
         gridLayer.setForegroundColor(DesignResources.GRID_COLOR);
 
         IAction action = new ToggleGridAction(viewer);
-        this.getActionRegistry().registerAction(action);
+        getActionRegistry().registerAction(action);
 
-        action = new ChangeBackgroundColorAction(this, this.diagram);
-        this.getActionRegistry().registerAction(action);
-        this.getSelectionActions().add(action.getId());
+        action = new ChangeBackgroundColorAction(this, diagram);
+        getActionRegistry().registerAction(action);
+        getSelectionActions().add(action.getId());
 
         action = new ToggleMainColumnAction(this);
-        this.getActionRegistry().registerAction(action);
+        getActionRegistry().registerAction(action);
 
         action = new LockEditAction(this);
-        this.getActionRegistry().registerAction(action);
+        getActionRegistry().registerAction(action);
 
         action = new ExportToDBAction(this);
-        this.getActionRegistry().registerAction(action);
+        getActionRegistry().registerAction(action);
 
-        this.actionBarContributor = new ERDiagramActionBarContributor(this.zoomComboContributionItem);
+        this.actionBarContributor = new ERDiagramActionBarContributor(zoomComboContributionItem);
     }
 
     protected void initDragAndDrop(GraphicalViewer viewer) {
@@ -355,7 +355,7 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
     }
 
     private void addKeyHandler(IAction action) {
-        final IHandlerService service = (IHandlerService) this.getSite().getService(IHandlerService.class);
+        final IHandlerService service = (IHandlerService) getSite().getService(IHandlerService.class);
         service.activateHandler(action.getActionDefinitionId(), new ActionHandler(action));
     }
 
@@ -366,8 +366,8 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
         if (editorPart instanceof ERFluteMultiPageEditor) {
             final ERFluteMultiPageEditor multiPageEditorPart = (ERFluteMultiPageEditor) editorPart;
 
-            if (this.equals(multiPageEditorPart.getActiveEditor())) {
-                updateActions(this.getSelectionActions());
+            if (equals(multiPageEditorPart.getActiveEditor())) {
+                updateActions(getSelectionActions());
             }
         } else {
             super.selectionChanged(part, selection);
@@ -375,12 +375,12 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
     }
 
     public Point getLocation() {
-        final FigureCanvas canvas = (FigureCanvas) this.getGraphicalViewer().getControl();
+        final FigureCanvas canvas = (FigureCanvas) getGraphicalViewer().getControl();
         return canvas.getViewport().getViewLocation();
     }
 
     public void setLocation(int x, int y) {
-        final FigureCanvas canvas = (FigureCanvas) this.getGraphicalViewer().getControl();
+        final FigureCanvas canvas = (FigureCanvas) getGraphicalViewer().getControl();
         canvas.scrollTo(x, y);
     }
 
@@ -389,15 +389,15 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
     }
 
     public void setMarkedObject(IMarker marker, Object markedObject) {
-        this.markedObjectMap.put(marker, markedObject);
+        markedObjectMap.put(marker, markedObject);
     }
 
     public void clearMarkedObject() {
-        this.markedObjectMap.clear();
+        markedObjectMap.clear();
     }
 
     public String getProjectFilePath(String extention) {
-        final IFile file = ((IFileEditorInput) this.getEditorInput()).getFile();
+        final IFile file = ((IFileEditorInput) getEditorInput()).getFile();
         final String filePath = file.getLocation().toOSString();
         return filePath.substring(0, filePath.lastIndexOf(".")) + extention;
     }
@@ -446,7 +446,7 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
 
     @Override
     public boolean isDirty() {
-        return this.isDirty || super.isDirty();
+        return isDirty || super.isDirty();
     }
 
     public void setDirty(boolean isDirty) {

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -233,17 +233,6 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
 
     public void changeCategory() {
         this.outlinePage.setCategory(this.getEditDomain(), this.getGraphicalViewer(), this.getActionRegistry());
-        /*
-         * TODO バグ修正のためコメント化
-         * "アウトラインで仮想ダイアグラムをダブルクリックで開く→開いたエディタクリック→別の仮想ダイアグラムをダブルクリックで開く"操作をする。
-         * するとアウトライン上で、ダブルクリックした仮想ダイアグラムでなく、エディタクリック時の仮想ダイアグラムが選択されている。
-         * この問題を修正するため、以下をコメント化した。
-         *
-         * [既知の副作用]
-         * ・仮想ダイアグラムエディタをクリックしてもツリー上の仮想ダイアグラムが選択されない。
-         *  →ツリービューの選択している箇所から強制スクロールされなくなるので、むしろ良いかもしれない。
-         */
-        //this.getSelectionSynchronizer().addViewer(this.outlinePage.getViewer());
     }
 
     @Override
@@ -254,8 +243,8 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
         super.setFocus();
     }
 
-    public void removeSelection() {
-        this.getSelectionSynchronizer().removeViewer(this.outlinePage.getViewer());
+    public void addSelection() {
+        this.getSelectionSynchronizer().addViewer(this.outlinePage.getViewer());
     }
 
     // TODO jflute ermaster: 何度も呼ばれている疑惑、増えていく増えていく

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -122,6 +122,30 @@ import org.eclipse.ui.views.properties.PropertySheetPage;
  */
 public class MainDiagramEditor extends GraphicalEditorWithPalette { // created by ERFluteMultiPageEditor
 
+    /*
+     * TODO ymd イケてない
+     * アウトラインで選択したテーブルを取得する方法が分からなかったため、以下のようなダメ実装にした。
+     */
+    private static EditPart quickOutlineSelectionEditPart;
+
+    /*
+     * Quick Outlineで検索したテーブルを選択する。
+     */
+    protected static void selectEditPartFromQuickOutline(EditPart editPart) {
+        unselectEditPartByQuickOutline();
+        quickOutlineSelectionEditPart = editPart;
+        quickOutlineSelectionEditPart.setSelected(EditPart.SELECTED_PRIMARY);
+    }
+
+    /*
+     * Quick Outlineで検索したテーブルを未選択にする。
+     */
+    protected static void unselectEditPartByQuickOutline() {
+        if (quickOutlineSelectionEditPart != null) {
+            quickOutlineSelectionEditPart.setSelected(EditPart.SELECTED_NONE);
+        }
+    }
+
     // ===================================================================================
     //                                                                          Definition
     //                                                                          ==========
@@ -363,11 +387,10 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
     @Override
     public void selectionChanged(IWorkbenchPart part, ISelection selection) {
         final IEditorPart editorPart = getSite().getPage().getActiveEditor();
-
         if (editorPart instanceof ERFluteMultiPageEditor) {
             final ERFluteMultiPageEditor multiPageEditorPart = (ERFluteMultiPageEditor) editorPart;
-
             if (equals(multiPageEditorPart.getActiveEditor())) {
+                unselectEditPartByQuickOutline();
                 updateActions(getSelectionActions());
             }
         } else {
@@ -419,7 +442,7 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
                 final ERTableEditPart vtableEditPart = (ERTableEditPart) tableEditPart;
                 if (((ERTable) vtableEditPart.getModel()).equals(table)) {
                     getGraphicalViewer().reveal(vtableEditPart);
-                    vtableEditPart.setSelected(EditPart.SELECTED_PRIMARY); // Quick Outlineで検索したテーブルを選択する
+                    selectEditPartFromQuickOutline(vtableEditPart);
                     return;
                 }
             }
@@ -453,5 +476,9 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
 
     public void setDirty(boolean isDirty) {
         this.isDirty = isDirty;
+    }
+
+    public void runERDiagramQuickOutlineAction() {
+        getActionRegistry().getAction(ERDiagramQuickOutlineAction.ID).runWithEvent(null);
     }
 }

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -419,7 +419,7 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
                 final ERTableEditPart vtableEditPart = (ERTableEditPart) tableEditPart;
                 if (((ERTable) vtableEditPart.getModel()).equals(table)) {
                     getGraphicalViewer().reveal(vtableEditPart);
-                    vtableEditPart.setSelected(EditPart.SELECTED); // Quick Outlineで検索したテーブルを選択する
+                    vtableEditPart.setSelected(EditPart.SELECTED_PRIMARY); // Quick Outlineで検索したテーブルを選択する
                     return;
                 }
             }

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -194,14 +194,18 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
         viewer.setProperty(SnapToGrid.PROPERTY_GRID_VISIBLE, true);
         viewer.setProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED, true);
 
-        final MenuManager menuMgr = new ERDiagramPopupMenuManager(getActionRegistry(), diagram);
-        this.extensionLoader.addERDiagramPopupMenu(menuMgr, getActionRegistry());
-        viewer.setContextMenu(menuMgr);
+        prepareERDiagramPopupMenu(viewer);
 
         this.outlineMenuMgr = new ERDiagramOutlinePopupMenuManager(diagram, getActionRegistry(), outlinePage.getOutlineActionRegistory(),
                 outlinePage.getViewer());
         outlinePage.setContextMenu(outlineMenuMgr);
         this.gotoMaker = new ERDiagramGotoMarker(this);
+    }
+
+    protected void prepareERDiagramPopupMenu(final GraphicalViewer viewer) {
+        final MenuManager menuMgr = new ERDiagramPopupMenuManager(getActionRegistry(), diagram);
+        extensionLoader.addERDiagramPopupMenu(menuMgr, getActionRegistry());
+        viewer.setContextMenu(menuMgr);
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -260,6 +260,17 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
         outlinePage.setCategory(getEditDomain(), getGraphicalViewer(), getActionRegistry());
     }
 
+    public void clearSelection() {
+        if (!(getGraphicalViewer().getContents() instanceof ERDiagramEditPart)) {
+            return;
+        }
+
+        final ERDiagramEditPart erDiagramEditPart = (ERDiagramEditPart) getGraphicalViewer().getContents();
+        if (erDiagramEditPart != null) {
+            erDiagramEditPart.clearSelection();
+        }
+    }
+
     @Override
     public void setFocus() {
         if (getGraphicalViewer().getContents() == null) {
@@ -386,11 +397,12 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
 
     @Override
     public void selectionChanged(IWorkbenchPart part, ISelection selection) {
+        unselectEditPartByQuickOutline();
+
         final IEditorPart editorPart = getSite().getPage().getActiveEditor();
         if (editorPart instanceof ERFluteMultiPageEditor) {
             final ERFluteMultiPageEditor multiPageEditorPart = (ERFluteMultiPageEditor) editorPart;
             if (equals(multiPageEditorPart.getActiveEditor())) {
-                unselectEditPartByQuickOutline();
                 updateActions(getSelectionActions());
             }
         } else {

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -233,7 +233,17 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
 
     public void changeCategory() {
         this.outlinePage.setCategory(this.getEditDomain(), this.getGraphicalViewer(), this.getActionRegistry());
-        this.getSelectionSynchronizer().addViewer(this.outlinePage.getViewer());
+        /*
+         * TODO バグ修正のためコメント化
+         * "アウトラインで仮想ダイアグラムをダブルクリックで開く→開いたエディタクリック→別の仮想ダイアグラムをダブルクリックで開く"操作をする。
+         * するとアウトライン上で、ダブルクリックした仮想ダイアグラムでなく、エディタクリック時の仮想ダイアグラムが選択されている。
+         * この問題を修正するため、以下をコメント化した。
+         *
+         * [既知の副作用]
+         * ・仮想ダイアグラムエディタをクリックしてもツリー上の仮想ダイアグラムが選択されない。
+         *  →ツリービューの選択している箇所から強制スクロールされなくなるので、むしろ良いかもしれない。
+         */
+        //this.getSelectionSynchronizer().addViewer(this.outlinePage.getViewer());
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -185,21 +185,22 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
 
     @Override
     protected void initializeGraphicalViewer() {
-        final GraphicalViewer viewer = this.getGraphicalViewer();
+        final GraphicalViewer viewer = getGraphicalViewer();
         viewer.setEditPartFactory(editPartFactory);
-        this.initViewerAction(viewer);
-        this.initDragAndDrop(viewer);
+        initViewerAction(viewer);
+        initDragAndDrop(viewer);
         viewer.setProperty(MouseWheelHandler.KeyGenerator.getKey(SWT.MOD1), MouseWheelZoomHandler.SINGLETON);
         viewer.setProperty(SnapToGrid.PROPERTY_GRID_ENABLED, true);
         viewer.setProperty(SnapToGrid.PROPERTY_GRID_VISIBLE, true);
         viewer.setProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED, true);
-        final ActionRegistry actionRegistry = getActionRegistry();
-        final MenuManager menuMgr = new ERDiagramPopupMenuManager(actionRegistry, this.diagram);
-        this.extensionLoader.addERDiagramPopupMenu(menuMgr, actionRegistry);
+
+        final MenuManager menuMgr = new ERDiagramPopupMenuManager(getActionRegistry(), diagram);
+        this.extensionLoader.addERDiagramPopupMenu(menuMgr, getActionRegistry());
         viewer.setContextMenu(menuMgr);
-        final ActionRegistry outlineActionRegistory = outlinePage.getOutlineActionRegistory();
-        this.outlineMenuMgr =
-                new ERDiagramOutlinePopupMenuManager(diagram, actionRegistry, outlineActionRegistory, outlinePage.getViewer());
+
+        this.outlineMenuMgr = new ERDiagramOutlinePopupMenuManager(diagram, getActionRegistry(), outlinePage.getOutlineActionRegistory(),
+                outlinePage.getViewer());
+        outlinePage.setContextMenu(outlineMenuMgr);
         this.gotoMaker = new ERDiagramGotoMarker(this);
     }
 
@@ -227,7 +228,7 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
     }
 
     public void changeCategory() {
-        this.outlinePage.setCategory(this.getEditDomain(), this.getGraphicalViewer(), this.outlineMenuMgr, this.getActionRegistry());
+        this.outlinePage.setCategory(this.getEditDomain(), this.getGraphicalViewer(), this.getActionRegistry());
         this.getSelectionSynchronizer().addViewer(this.outlinePage.getViewer());
     }
 

--- a/src/org/dbflute/erflute/editor/MainDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/MainDiagramEditor.java
@@ -82,6 +82,7 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.DefaultEditDomain;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.MouseWheelHandler;
@@ -418,6 +419,7 @@ public class MainDiagramEditor extends GraphicalEditorWithPalette { // created b
                 final ERTableEditPart vtableEditPart = (ERTableEditPart) tableEditPart;
                 if (((ERTable) vtableEditPart.getModel()).equals(table)) {
                     getGraphicalViewer().reveal(vtableEditPart);
+                    vtableEditPart.setSelected(EditPart.SELECTED); // Quick Outlineで検索したテーブルを選択する
                     return;
                 }
             }

--- a/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
@@ -17,7 +17,6 @@ import org.dbflute.erflute.editor.view.action.ermodel.PlaceTableAction;
 import org.dbflute.erflute.editor.view.action.ermodel.WalkerGroupManageAction;
 import org.dbflute.erflute.editor.view.outline.ERDiagramOutlinePage;
 import org.eclipse.gef.DefaultEditDomain;
-import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.gef.ui.actions.ZoomComboContributionItem;
@@ -106,7 +105,7 @@ public class VirtualDiagramEditor extends MainDiagramEditor { // created by ERFl
                 final ERVirtualTableEditPart vtableEditPart = (ERVirtualTableEditPart) tableEditPart;
                 if (((ERVirtualTable) vtableEditPart.getModel()).getRawTable().equals(table)) {
                     getGraphicalViewer().reveal(vtableEditPart);
-                    vtableEditPart.setSelected(EditPart.SELECTED_PRIMARY); // Quick Outlineで検索したテーブルを選択する
+                    selectEditPartFromQuickOutline(vtableEditPart);
                     return;
                 }
             }

--- a/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
@@ -70,7 +70,7 @@ public class VirtualDiagramEditor extends MainDiagramEditor { // created by ERFl
         super.createActions();
         final ActionRegistry registry = getActionRegistry();
         final List<IAction> actionList =
-                new ArrayList<IAction>(Arrays.asList(new IAction[] { new PlaceTableAction(this), new WalkerGroupManageAction(this), }));
+                new ArrayList<>(Arrays.asList(new IAction[] { new PlaceTableAction(this), new WalkerGroupManageAction(this), }));
         for (final IAction action : actionList) {
             registry.registerAction(action);
         }
@@ -81,24 +81,24 @@ public class VirtualDiagramEditor extends MainDiagramEditor { // created by ERFl
     //                                                                     ===============
     @Override
     protected void initializeGraphicalViewer() {
-        final GraphicalViewer viewer = this.getGraphicalViewer();
+        final GraphicalViewer viewer = getGraphicalViewer();
         viewer.setEditPartFactory(editPartFactory);
-
-        this.initViewerAction(viewer);
-        this.initDragAndDrop(viewer);
-
+        initViewerAction(viewer);
+        initDragAndDrop(viewer);
         viewer.setProperty(MouseWheelHandler.KeyGenerator.getKey(SWT.MOD1), MouseWheelZoomHandler.SINGLETON);
         viewer.setProperty(SnapToGrid.PROPERTY_GRID_ENABLED, true);
         viewer.setProperty(SnapToGrid.PROPERTY_GRID_VISIBLE, true);
         viewer.setProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED, true);
 
-        final MenuManager menuMgr = new ERVirtualDiagramPopupMenuManager(this.getActionRegistry(), this.vdiagram);
-        this.extensionLoader.addERDiagramPopupMenu(menuMgr, this.getActionRegistry());
+        final MenuManager menuMgr = new ERVirtualDiagramPopupMenuManager(getActionRegistry(), vdiagram);
+        this.extensionLoader.addERDiagramPopupMenu(menuMgr, getActionRegistry());
         viewer.setContextMenu(menuMgr);
         viewer.setContents(vdiagram);
-        this.outlineMenuMgr =
-                new ERDiagramOutlinePopupMenuManager(this.diagram, this.getActionRegistry(), this.outlinePage.getOutlineActionRegistory(),
-                        this.outlinePage.getViewer());
+
+        this.outlineMenuMgr = new ERDiagramOutlinePopupMenuManager(diagram, getActionRegistry(), outlinePage.getOutlineActionRegistory(),
+                outlinePage.getViewer());
+        outlinePage.setContextMenu(outlineMenuMgr);
+
         this.gotoMaker = new ERDiagramGotoMarker(this);
     }
 

--- a/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
@@ -17,6 +17,7 @@ import org.dbflute.erflute.editor.view.action.ermodel.PlaceTableAction;
 import org.dbflute.erflute.editor.view.action.ermodel.WalkerGroupManageAction;
 import org.dbflute.erflute.editor.view.outline.ERDiagramOutlinePage;
 import org.eclipse.gef.DefaultEditDomain;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.gef.ui.actions.ZoomComboContributionItem;
@@ -75,7 +76,7 @@ public class VirtualDiagramEditor extends MainDiagramEditor { // created by ERFl
     @Override
     protected void prepareERDiagramPopupMenu(final GraphicalViewer viewer) {
         final MenuManager menuMgr = new ERVirtualDiagramPopupMenuManager(getActionRegistry(), vdiagram);
-        this.extensionLoader.addERDiagramPopupMenu(menuMgr, getActionRegistry());
+        extensionLoader.addERDiagramPopupMenu(menuMgr, getActionRegistry());
         viewer.setContextMenu(menuMgr);
         viewer.setContents(vdiagram);
     }
@@ -105,6 +106,7 @@ public class VirtualDiagramEditor extends MainDiagramEditor { // created by ERFl
                 final ERVirtualTableEditPart vtableEditPart = (ERVirtualTableEditPart) tableEditPart;
                 if (((ERVirtualTable) vtableEditPart.getModel()).getRawTable().equals(table)) {
                     getGraphicalViewer().reveal(vtableEditPart);
+                    vtableEditPart.setSelected(EditPart.SELECTED); // Quick Outlineで検索したテーブルを選択する
                     return;
                 }
             }

--- a/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
@@ -106,7 +106,7 @@ public class VirtualDiagramEditor extends MainDiagramEditor { // created by ERFl
                 final ERVirtualTableEditPart vtableEditPart = (ERVirtualTableEditPart) tableEditPart;
                 if (((ERVirtualTable) vtableEditPart.getModel()).getRawTable().equals(table)) {
                     getGraphicalViewer().reveal(vtableEditPart);
-                    vtableEditPart.setSelected(EditPart.SELECTED); // Quick Outlineで検索したテーブルを選択する
+                    vtableEditPart.setSelected(EditPart.SELECTED_PRIMARY); // Quick Outlineで検索したテーブルを選択する
                     return;
                 }
             }

--- a/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
+++ b/src/org/dbflute/erflute/editor/VirtualDiagramEditor.java
@@ -12,23 +12,16 @@ import org.dbflute.erflute.editor.model.ERDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERVirtualTable;
-import org.dbflute.erflute.editor.view.ERDiagramGotoMarker;
 import org.dbflute.erflute.editor.view.ERVirtualDiagramPopupMenuManager;
 import org.dbflute.erflute.editor.view.action.ermodel.PlaceTableAction;
 import org.dbflute.erflute.editor.view.action.ermodel.WalkerGroupManageAction;
 import org.dbflute.erflute.editor.view.outline.ERDiagramOutlinePage;
-import org.dbflute.erflute.editor.view.outline.ERDiagramOutlinePopupMenuManager;
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.GraphicalViewer;
-import org.eclipse.gef.MouseWheelHandler;
-import org.eclipse.gef.MouseWheelZoomHandler;
-import org.eclipse.gef.SnapToGeometry;
-import org.eclipse.gef.SnapToGrid;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.gef.ui.actions.ZoomComboContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
-import org.eclipse.swt.SWT;
 
 /**
  * @author modified by jflute (originated in ermaster)
@@ -80,26 +73,11 @@ public class VirtualDiagramEditor extends MainDiagramEditor { // created by ERFl
     //                                                                     GraphicalViewer
     //                                                                     ===============
     @Override
-    protected void initializeGraphicalViewer() {
-        final GraphicalViewer viewer = getGraphicalViewer();
-        viewer.setEditPartFactory(editPartFactory);
-        initViewerAction(viewer);
-        initDragAndDrop(viewer);
-        viewer.setProperty(MouseWheelHandler.KeyGenerator.getKey(SWT.MOD1), MouseWheelZoomHandler.SINGLETON);
-        viewer.setProperty(SnapToGrid.PROPERTY_GRID_ENABLED, true);
-        viewer.setProperty(SnapToGrid.PROPERTY_GRID_VISIBLE, true);
-        viewer.setProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED, true);
-
+    protected void prepareERDiagramPopupMenu(final GraphicalViewer viewer) {
         final MenuManager menuMgr = new ERVirtualDiagramPopupMenuManager(getActionRegistry(), vdiagram);
         this.extensionLoader.addERDiagramPopupMenu(menuMgr, getActionRegistry());
         viewer.setContextMenu(menuMgr);
         viewer.setContents(vdiagram);
-
-        this.outlineMenuMgr = new ERDiagramOutlinePopupMenuManager(diagram, getActionRegistry(), outlinePage.getOutlineActionRegistory(),
-                outlinePage.getViewer());
-        outlinePage.setContextMenu(outlineMenuMgr);
-
-        this.gotoMaker = new ERDiagramGotoMarker(this);
     }
 
     // ===================================================================================

--- a/src/org/dbflute/erflute/editor/controller/command/AbstractCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/AbstractCommand.java
@@ -8,9 +8,10 @@ public abstract class AbstractCommand extends Command {
     @Override
     final public void execute() {
         try {
+            Activator.debug(this, "doExecute", "Before");
             doExecute();
-
-        } catch (Exception e) {
+            Activator.debug(this, "doExecute", "After");
+        } catch (final Exception e) {
             Activator.showExceptionDialog(e);
         }
     }
@@ -19,7 +20,7 @@ public abstract class AbstractCommand extends Command {
     final public void undo() {
         try {
             doUndo();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Activator.showExceptionDialog(e);
         }
     }

--- a/src/org/dbflute/erflute/editor/controller/command/common/PasteCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/common/PasteCommand.java
@@ -43,7 +43,7 @@ public class PasteCommand extends AbstractCommand {
 
         this.columnGroups = new ColumnGroupSet();
 
-        // 貼り付け対象に対して処理を繰り返します
+        // 貼り付け対象に対して処理を繰り返します。
         for (final DiagramWalker walker : walkers) {
             walker.setLocation(new Location(walker.getX() + x, walker.getY() + y, walker.getWidth(), walker.getHeight()));
 
@@ -61,7 +61,7 @@ public class PasteCommand extends AbstractCommand {
                     }
                 }
 
-                // 列に対して処理を繰り返します
+                // 列に対して処理を繰り返します。
                 for (final ERColumn column : table.getColumns()) {
 
                     // 列がグループ列の場合
@@ -87,19 +87,15 @@ public class PasteCommand extends AbstractCommand {
         // 描画更新をとめます。
         ERDiagramEditPart.setUpdateable(false);
 
-        final ColumnGroupSet columnGroupSet = this.diagram.getDiagramContents().getColumnGroupSet();
+        final ColumnGroupSet columnGroupSet = diagram.getDiagramContents().getColumnGroupSet();
 
         // 図にノードを追加します。
-        for (final DiagramWalker walker : this.walkers) {
-            if (this.diagram.getCurrentVirtualDiagram() != null && !(walker instanceof ERTable)) {
-                this.diagram.getCurrentVirtualDiagram().addNewWalker(walker);
-            } else {
-                this.diagram.addWalkerPlainly(walker);
-            }
+        for (final DiagramWalker walker : walkers) {
+            diagram.addWalkerPlainly(walker);
         }
 
         // グループ列を追加します。
-        for (final ColumnGroup columnGroup : this.columnGroups) {
+        for (final ColumnGroup columnGroup : columnGroups) {
             columnGroupSet.add(columnGroup);
         }
 
@@ -109,7 +105,7 @@ public class PasteCommand extends AbstractCommand {
         ERModelUtil.refreshDiagram(diagram);
 
         // 貼り付けられたテーブルを選択状態にします。
-        this.setFocus();
+        setFocus();
     }
 
     /**
@@ -120,15 +116,15 @@ public class PasteCommand extends AbstractCommand {
         // 描画更新をとめます。
         ERDiagramEditPart.setUpdateable(false);
 
-        final ColumnGroupSet columnGroupSet = this.diagram.getDiagramContents().getColumnGroupSet();
+        final ColumnGroupSet columnGroupSet = diagram.getDiagramContents().getColumnGroupSet();
 
         // 図からノードを削除します。
-        for (final DiagramWalker walker : this.walkers) {
-            this.diagram.removeContent(walker);
+        for (final DiagramWalker walker : walkers) {
+            diagram.removeContent(walker);
         }
 
         // グループ列を削除します。
-        for (final ColumnGroup columnGroup : this.columnGroups) {
+        for (final ColumnGroup columnGroup : columnGroups) {
             columnGroupSet.remove(columnGroup);
         }
 
@@ -143,11 +139,11 @@ public class PasteCommand extends AbstractCommand {
      */
     private void setFocus() {
         // 貼り付けられたテーブルを選択状態にします。
-        for (final DiagramWalker walker : this.walkers) {
+        for (final DiagramWalker walker : walkers) {
             final EditPart editPart = (EditPart) viewer.getEditPartRegistry().get(walker);
 
             if (editPart != null) {
-                this.viewer.getSelectionManager().appendSelection(editPart);
+                viewer.getSelectionManager().appendSelection(editPart);
             }
         }
     }

--- a/src/org/dbflute/erflute/editor/controller/command/dbimport/ImportTableCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/dbimport/ImportTableCommand.java
@@ -86,8 +86,8 @@ public class ImportTableCommand extends AbstractCommand {
 
             for (final DiagramWalker walker : walkerList) {
                 for (final WalkerConnection outgoing : walker.getOutgoings()) {
-                    final Node sourceNode = nodeElementNodeMap.get(outgoing.getWalkerSource());
-                    final Node targetNode = nodeElementNodeMap.get(outgoing.getWalkerTarget());
+                    final Node sourceNode = nodeElementNodeMap.get(outgoing.getSourceWalker());
+                    final Node targetNode = nodeElementNodeMap.get(outgoing.getTargetWalker());
                     if (sourceNode != targetNode) {
                         final Edge edge = new Edge(sourceNode, targetNode);
                         graph.edges.add(edge);
@@ -170,7 +170,7 @@ public class ImportTableCommand extends AbstractCommand {
             if (otherRelation == relation) {
                 continue;
             }
-            if (otherRelation.getWalkerSource() == otherRelation.getWalkerTarget()) {
+            if (otherRelation.getSourceWalker() == otherRelation.getTargetWalker()) {
                 anotherSelfRelation = true;
                 break;
             }

--- a/src/org/dbflute/erflute/editor/controller/command/dbimport/ImportTableCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/dbimport/ImportTableCommand.java
@@ -32,35 +32,23 @@ import org.eclipse.draw2d.graph.Node;
 public class ImportTableCommand extends AbstractCommand {
 
     private final ERDiagram diagram;
-
     private final SequenceSet sequenceSet;
-
     private final TriggerSet triggerSet;
-
     private final TablespaceSet tablespaceSet;
-
     private final ColumnGroupSet columnGroupSet;
-
     private final List<DiagramWalker> walkerList;
-
     private final List<Sequence> sequences;
-
     private final List<Trigger> triggers;
-
     private final List<Tablespace> tablespaces;
-
     private final List<ColumnGroup> columnGroups;
 
     private DirectedGraph graph = new DirectedGraph();
 
     private static final int AUTO_GRAPH_LIMIT = 100;
-
     private static final int ORIGINAL_X = 20;
     private static final int ORIGINAL_Y = 20;
-
     private static final int DISTANCE_X = 300;
     private static final int DISTANCE_Y = 300;
-
     private static final int SIZE_X = 6;
 
     public ImportTableCommand(ERDiagram diagram, List<DiagramWalker> walkerList, List<Sequence> sequences, List<Trigger> triggers,
@@ -72,43 +60,42 @@ public class ImportTableCommand extends AbstractCommand {
         this.tablespaces = tablespaces;
         this.columnGroups = columnGroups;
 
-        final DiagramContents diagramContents = this.diagram.getDiagramContents();
-
+        final DiagramContents diagramContents = diagram.getDiagramContents();
         this.sequenceSet = diagramContents.getSequenceSet();
         this.triggerSet = diagramContents.getTriggerSet();
         this.tablespaceSet = diagramContents.getTablespaceSet();
         this.columnGroupSet = diagramContents.getColumnGroupSet();
 
-        this.decideLocation();
+        decideLocation();
     }
 
     @SuppressWarnings("unchecked")
     private void decideLocation() {
         this.graph = new DirectedGraph();
 
-        if (this.walkerList.size() < AUTO_GRAPH_LIMIT) {
+        if (walkerList.size() < AUTO_GRAPH_LIMIT) {
             final Map<DiagramWalker, Node> nodeElementNodeMap = new HashMap<>();
-            final int fontSize = this.diagram.getFontSize();
+            final int fontSize = diagram.getFontSize();
             final Insets insets = new Insets(5 * fontSize, 10 * fontSize, 35 * fontSize, 20 * fontSize);
-            for (final DiagramWalker walker : this.walkerList) {
+            for (final DiagramWalker walker : walkerList) {
                 final Node node = new Node();
                 node.setPadding(insets);
-                this.graph.nodes.add(node);
+                graph.nodes.add(node);
                 nodeElementNodeMap.put(walker, node);
             }
 
-            for (final DiagramWalker walker : this.walkerList) {
+            for (final DiagramWalker walker : walkerList) {
                 for (final WalkerConnection outgoing : walker.getOutgoings()) {
                     final Node sourceNode = nodeElementNodeMap.get(outgoing.getWalkerSource());
                     final Node targetNode = nodeElementNodeMap.get(outgoing.getWalkerTarget());
                     if (sourceNode != targetNode) {
                         final Edge edge = new Edge(sourceNode, targetNode);
-                        this.graph.edges.add(edge);
+                        graph.edges.add(edge);
                     }
                 }
             }
             final DirectedGraphLayout layout = new DirectedGraphLayout();
-            layout.visit(this.graph);
+            layout.visit(graph);
             for (final DiagramWalker walker : nodeElementNodeMap.keySet()) {
                 final Node node = nodeElementNodeMap.get(walker);
                 if (walker.getWidth() == 0) {
@@ -119,7 +106,7 @@ public class ImportTableCommand extends AbstractCommand {
             int x = ORIGINAL_X;
             int y = ORIGINAL_Y;
 
-            for (final DiagramWalker nodeElement : this.walkerList) {
+            for (final DiagramWalker nodeElement : walkerList) {
                 if (nodeElement.getWidth() == 0) {
                     nodeElement.setLocation(new Location(x, y, -1, -1));
 
@@ -135,22 +122,22 @@ public class ImportTableCommand extends AbstractCommand {
 
     @Override
     protected void doExecute() {
-        if (this.columnGroups != null) {
+        if (columnGroups != null) {
             for (final ColumnGroup columnGroup : columnGroups) {
-                this.columnGroupSet.add(columnGroup);
+                columnGroupSet.add(columnGroup);
             }
         }
 
         ERDiagramEditPart.setUpdateable(false);
 
-        for (final DiagramWalker walker : this.walkerList) {
-            this.diagram.addNewWalker(walker);
+        for (final DiagramWalker walker : walkerList) {
+            diagram.addNewWalker(walker);
             if (walker instanceof TableView) {
                 for (final NormalColumn normalColumn : ((TableView) walker).getNormalColumns()) {
                     if (normalColumn.isForeignKey()) {
                         for (final Relationship relation : normalColumn.getRelationshipList()) {
                             if (relation.getSourceTableView() == walker) {
-                                this.setSelfRelation(relation);
+                                setSelfRelation(relation);
                             }
                         }
                     }
@@ -159,20 +146,20 @@ public class ImportTableCommand extends AbstractCommand {
         }
 
         for (final Sequence sequence : sequences) {
-            this.sequenceSet.addSequence(sequence);
+            sequenceSet.addSequence(sequence);
         }
 
         for (final Trigger trigger : triggers) {
-            this.triggerSet.addTrigger(trigger);
+            triggerSet.addTrigger(trigger);
         }
 
         for (final Tablespace tablespace : tablespaces) {
-            this.tablespaceSet.addTablespace(tablespace);
+            tablespaceSet.addTablespace(tablespace);
         }
 
         ERDiagramEditPart.setUpdateable(true);
 
-        this.diagram.changeAll(this.walkerList);
+        diagram.changeAll(walkerList);
     }
 
     private void setSelfRelation(Relationship relation) {
@@ -213,29 +200,29 @@ public class ImportTableCommand extends AbstractCommand {
     @Override
     protected void doUndo() {
         ERDiagramEditPart.setUpdateable(false);
-        for (final DiagramWalker walker : this.walkerList) {
-            this.diagram.removeContent(walker);
+        for (final DiagramWalker walker : walkerList) {
+            diagram.removeWalker(walker);
             if (walker instanceof TableView) {
                 for (final NormalColumn normalColumn : ((TableView) walker).getNormalColumns()) {
-                    this.diagram.getDiagramContents().getDictionary().remove(normalColumn);
+                    diagram.getDiagramContents().getDictionary().remove(normalColumn);
                 }
             }
         }
         for (final Sequence sequence : sequences) {
-            this.sequenceSet.remove(sequence);
+            sequenceSet.remove(sequence);
         }
         for (final Trigger trigger : triggers) {
-            this.triggerSet.remove(trigger);
+            triggerSet.remove(trigger);
         }
         for (final Tablespace tablespace : tablespaces) {
-            this.tablespaceSet.remove(tablespace);
+            tablespaceSet.remove(tablespace);
         }
-        if (this.columnGroups != null) {
+        if (columnGroups != null) {
             for (final ColumnGroup columnGroup : columnGroups) {
-                this.columnGroupSet.remove(columnGroup);
+                columnGroupSet.remove(columnGroup);
             }
         }
         ERDiagramEditPart.setUpdateable(true);
-        this.diagram.changeAll();
+        diagram.changeAll();
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/CreateCommentConnectionCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/CreateCommentConnectionCommand.java
@@ -2,9 +2,8 @@ package org.dbflute.erflute.editor.controller.command.diagram_contents.element.c
 
 import org.dbflute.erflute.editor.model.ERModelUtil;
 import org.dbflute.erflute.editor.model.diagram_contents.element.connection.WalkerConnection;
+import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.note.WalkerNote;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERVirtualTable;
 
 /**
  * @author modified by jflute (originated in ermaster)
@@ -28,21 +27,27 @@ public class CreateCommentConnectionCommand extends CreateConnectionCommand {
 
     @Override
     protected void doExecute() {
-        // noteのoutgoingとしてconnectionを設定するため。
+        // noteをoutgoingとしてconnectionに設定する。
         // outgoingに設定されたconnectionをXMLに書き出す仕組みになっている。
+        // setSourceWalkerでoutgoingに設定される。
         connection.setSourceWalker(getNote());
-        connection.setTargetWalker(getERTable());
-        ERModelUtil.refreshDiagram(getERTable().getDiagram(), getERTable());
+        connection.setTargetWalker(getNotNote());
+        ERModelUtil.refreshDiagram(getNotNote().getDiagram());
     }
 
     private WalkerNote getNote() {
-        final WalkerNote note = getSourceModel() instanceof WalkerNote ? (WalkerNote) getSourceModel() : (WalkerNote) getTargetModel();
-        return note;
+        if ((getSourceModel() instanceof WalkerNote && getTargetModel() instanceof WalkerNote)) {
+            return (WalkerNote) getSourceModel();
+        } else if (getSourceModel() instanceof WalkerNote) {
+            return (WalkerNote) getSourceModel();
+        } else if (getTargetModel() instanceof WalkerNote) {
+            return (WalkerNote) getTargetModel();
+        } else {
+            throw new IllegalStateException();
+        }
     }
 
-    private ERTable getERTable() {
-        final ERTable erTable = getSourceModel() instanceof ERTable ? (ERTable) getSourceModel() : (ERTable) getTargetModel();
-        final ERTable unwrapped = erTable instanceof ERVirtualTable ? ((ERVirtualTable) erTable).getRawTable() : erTable;
-        return unwrapped;
+    private DiagramWalker getNotNote() {
+        return (getNote() == getSourceModel() ? getTargetModel() : getSourceModel()).toMaterialize();
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/DeleteConnectionCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/DeleteConnectionCommand.java
@@ -2,22 +2,27 @@ package org.dbflute.erflute.editor.controller.command.diagram_contents.element.c
 
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
 import org.dbflute.erflute.editor.model.diagram_contents.element.connection.WalkerConnection;
+import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 
 public class DeleteConnectionCommand extends AbstractCommand {
 
-    private WalkerConnection connection;
+    private final WalkerConnection connection;
+    private final DiagramWalker sourceWalker;
+    private final DiagramWalker targetWalker;
 
     public DeleteConnectionCommand(WalkerConnection connection) {
         this.connection = connection;
+        this.sourceWalker = connection.getSourceWalker();
+        this.targetWalker = connection.getTargetWalker();
     }
 
     @Override
     protected void doExecute() {
-        this.connection.delete();
+        connection.delete();
     }
 
     @Override
     protected void doUndo() {
-        this.connection.connect();
+        connection.connect(sourceWalker, targetWalker);
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelatedTableCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelatedTableCommand.java
@@ -12,19 +12,12 @@ import org.eclipse.gef.EditPart;
 public class CreateRelatedTableCommand extends AbstractCreateRelationshipCommand {
 
     private Relationship relation1;
-
     private Relationship relation2;
-
-    private ERTable relatedTable;
-
+    private final ERTable relatedTable;
     private ERDiagram diagram;
-
     private int sourceX;
-
     private int sourceY;
-
     private int targetX;
-
     private int targetY;
 
     public CreateRelatedTableCommand() {
@@ -49,10 +42,10 @@ public class CreateRelatedTableCommand extends AbstractCreateRelationshipCommand
 
         if (target != null) {
             if (target instanceof TableViewEditPart) {
-                TableViewEditPart tableEditPart = (TableViewEditPart) target;
+                final TableViewEditPart tableEditPart = (TableViewEditPart) target;
 
-                Point point = tableEditPart.getFigure().getBounds().getCenter();
-                this.setTargetPoint(point.x, point.y);
+                final Point point = tableEditPart.getFigure().getBounds().getCenter();
+                setTargetPoint(point.x, point.y);
             }
         }
     }
@@ -61,53 +54,53 @@ public class CreateRelatedTableCommand extends AbstractCreateRelationshipCommand
     protected void doExecute() {
         ERDiagramEditPart.setUpdateable(false);
 
-        this.init();
+        init();
 
-        this.diagram.addNewWalker(this.relatedTable);
+        diagram.addNewWalker(relatedTable);
 
-        this.relation1.setSourceWalker((ERTable) this.source.getModel());
-        this.relation1.setTargetTableView(this.relatedTable);
+        relation1.setSourceWalker((ERTable) source.getModel());
+        relation1.setTargetTableView(relatedTable);
 
-        this.relation2.setSourceWalker((ERTable) this.target.getModel());
-        this.relation2.setTargetTableView(this.relatedTable);
+        relation2.setSourceWalker((ERTable) target.getModel());
+        relation2.setTargetTableView(relatedTable);
 
         ERDiagramEditPart.setUpdateable(true);
 
-        this.diagram.getDiagramContents().getDiagramWalkers().getTableSet().setDirty();
+        diagram.getDiagramContents().getDiagramWalkers().getTableSet().setDirty();
     }
 
     @Override
     protected void doUndo() {
         ERDiagramEditPart.setUpdateable(false);
 
-        this.diagram.removeContent(this.relatedTable);
+        diagram.removeWalker(relatedTable);
 
-        this.relation1.setSourceWalker(null);
-        this.relation1.setTargetTableView(null);
+        relation1.setSourceWalker(null);
+        relation1.setTargetTableView(null);
 
-        this.relation2.setSourceWalker(null);
-        this.relation2.setTargetTableView(null);
+        relation2.setSourceWalker(null);
+        relation2.setTargetTableView(null);
 
         ERDiagramEditPart.setUpdateable(true);
 
-        this.diagram.getDiagramContents().getDiagramWalkers().getTableSet().setDirty();
+        diagram.getDiagramContents().getDiagramWalkers().getTableSet().setDirty();
     }
 
     private void init() {
-        ERTable sourceTable = (ERTable) this.getSourceModel();
+        final ERTable sourceTable = (ERTable) getSourceModel();
 
         this.diagram = sourceTable.getDiagram();
 
         this.relation1 = sourceTable.createRelation();
 
-        ERTable targetTable = (ERTable) this.getTargetModel();
+        final ERTable targetTable = (ERTable) this.getTargetModel();
         this.relation2 = targetTable.createRelation();
 
-        this.relatedTable.setLocation(new Location((this.sourceX + this.targetX - ERTable.DEFAULT_WIDTH) / 2,
-                (this.sourceY + this.targetY - ERTable.DEFAULT_HEIGHT) / 2, ERTable.DEFAULT_WIDTH, ERTable.DEFAULT_HEIGHT));
+        relatedTable.setLocation(new Location((sourceX + targetX - ERTable.DEFAULT_WIDTH) / 2,
+                (sourceY + targetY - ERTable.DEFAULT_HEIGHT) / 2, ERTable.DEFAULT_WIDTH, ERTable.DEFAULT_HEIGHT));
 
-        this.relatedTable.setLogicalName(ERTable.NEW_LOGICAL_NAME);
-        this.relatedTable.setPhysicalName(ERTable.NEW_PHYSICAL_NAME);
+        relatedTable.setLogicalName(ERTable.NEW_LOGICAL_NAME);
+        relatedTable.setPhysicalName(ERTable.NEW_PHYSICAL_NAME);
 
     }
 
@@ -117,7 +110,7 @@ public class CreateRelatedTableCommand extends AbstractCreateRelationshipCommand
             return false;
         }
 
-        if (!(this.getSourceModel() instanceof ERTable) || !(this.getTargetModel() instanceof ERTable)) {
+        if (!(getSourceModel() instanceof ERTable) || !(getTargetModel() instanceof ERTable)) {
             return false;
         }
 

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByExistingColumnsCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByExistingColumnsCommand.java
@@ -159,8 +159,8 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
     }
 
     private void tellChangeToVirtualDiagram() {
-        if (relationship.getWalkerSource() instanceof ERTable || relationship.getWalkerTarget() instanceof ERTable) {
-            final ERVirtualDiagramSet vdiagramSet = relationship.getWalkerSource().getDiagram().getDiagramContents().getVirtualDiagramSet();
+        if (relationship.getSourceWalker() instanceof ERTable || relationship.getTargetWalker() instanceof ERTable) {
+            final ERVirtualDiagramSet vdiagramSet = relationship.getSourceWalker().getDiagram().getDiagramContents().getVirtualDiagramSet();
             vdiagramSet.createRelationship(relationship);
         }
     }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByExistingColumnsCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByExistingColumnsCommand.java
@@ -128,7 +128,7 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
         }
         tellChangeToVirtualDiagram();
         targetTable.setDirty();
-        ERModelUtil.refreshDiagram(relationship.getWalkerSource().getDiagram(), sourceTable);
+        ERModelUtil.refreshDiagram(sourceTable.getDiagram(), sourceTable);
     }
 
     private ERTable prepareSourceTable() {
@@ -172,11 +172,11 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
     protected void doUndo() {
         final ERTable sourceTable = (ERTable) source.getModel();
         final ERTable targetTable = (ERTable) target.getModel();
-        this.relationship.setSourceWalker(null);
-        this.relationship.setTargetWithoutForeignKey(null);
+        relationship.setSourceWalker(null);
+        relationship.setTargetWithoutForeignKey(null);
         for (int i = 0; i < selectedForeignKeyColumnList.size(); i++) {
             final NormalColumn foreignKeyColumn = selectedForeignKeyColumnList.get(i);
-            foreignKeyColumn.removeReference(this.relationship);
+            foreignKeyColumn.removeReference(relationship);
             foreignKeyColumn.setWord(wordList.get(i));
             sourceTable.getDiagram().getDiagramContents().getDictionary().add(foreignKeyColumn);
         }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByExistingColumnsCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByExistingColumnsCommand.java
@@ -38,7 +38,7 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
     //                                                                         Constructor
     //                                                                         ===========
     public CreateRelationshipByExistingColumnsCommand() {
-        this.wordList = new ArrayList<Word>();
+        this.wordList = new ArrayList<>();
     }
 
     // ===================================================================================
@@ -55,12 +55,11 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
             Activator.showErrorDialog("error.no.candidate.of.foreign.key.exist");
             return false;
         }
-        final Map<NormalColumn, List<NormalColumn>> existingRootReferredToFkColumnsMap = new HashMap<NormalColumn, List<NormalColumn>>();
-        final Map<Relationship, Set<NormalColumn>> existingRelationshipToFkColumnsMap = new HashMap<Relationship, Set<NormalColumn>>();
+        final Map<NormalColumn, List<NormalColumn>> existingRootReferredToFkColumnsMap = new HashMap<>();
+        final Map<Relationship, Set<NormalColumn>> existingRelationshipToFkColumnsMap = new HashMap<>();
         prepareExistingForeignColumnsMapping(targetTable, existingRootReferredToFkColumnsMap, existingRelationshipToFkColumnsMap);
-        final RelationshipByExistingColumnsDialog dialog =
-                createDialog(sourceTable, targetTable, candidateForeignKeyColumns, existingRootReferredToFkColumnsMap,
-                        existingRelationshipToFkColumnsMap);
+        final RelationshipByExistingColumnsDialog dialog = createDialog(sourceTable, targetTable, candidateForeignKeyColumns,
+                existingRootReferredToFkColumnsMap, existingRelationshipToFkColumnsMap);
         if (dialog.open() == IDialogConstants.OK_ID) {
             selectedReferredColumnList = dialog.getSelectedReferencedColumnList();
             selectedForeignKeyColumnList = dialog.getSelectedForeignKeyColumnList();
@@ -72,7 +71,7 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
     }
 
     private List<NormalColumn> prepareCandidateForeignKeyColumns(final TableView targetTable) {
-        final List<NormalColumn> candidateForeignKeyColumns = new ArrayList<NormalColumn>();
+        final List<NormalColumn> candidateForeignKeyColumns = new ArrayList<>();
         for (final NormalColumn column : targetTable.getNormalColumns()) {
             if (!column.isForeignKey()) {
                 candidateForeignKeyColumns.add(column);
@@ -89,14 +88,14 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
             if (firstRootReferredColumn != null) {
                 List<NormalColumn> foreignKeyColumnList = existingRootReferredToFkColumnsMap.get(firstRootReferredColumn);
                 if (foreignKeyColumnList == null) {
-                    foreignKeyColumnList = new ArrayList<NormalColumn>();
+                    foreignKeyColumnList = new ArrayList<>();
                     existingRootReferredToFkColumnsMap.put(firstRootReferredColumn, foreignKeyColumnList);
                 }
                 foreignKeyColumnList.add(normalColumn);
                 for (final Relationship relationship : normalColumn.getRelationshipList()) {
                     Set<NormalColumn> foreignKeyColumnSet = existingRelationshipToFkColumnsMap.get(relationship);
                     if (foreignKeyColumnSet == null) {
-                        foreignKeyColumnSet = new HashSet<NormalColumn>();
+                        foreignKeyColumnSet = new HashSet<>();
                         existingRelationshipToFkColumnsMap.put(relationship, foreignKeyColumnSet);
                     }
                     foreignKeyColumnSet.add(normalColumn);
@@ -182,5 +181,6 @@ public class CreateRelationshipByExistingColumnsCommand extends AbstractCreateRe
             sourceTable.getDiagram().getDiagramContents().getDictionary().add(foreignKeyColumn);
         }
         targetTable.setDirty();
+        ERModelUtil.refreshDiagram(sourceTable.getDiagram(), sourceTable);
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByNewColumnCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateRelationshipByNewColumnCommand.java
@@ -32,8 +32,8 @@ public class CreateRelationshipByNewColumnCommand extends AbstractCreateRelation
         relationship.setSourceWalker(sourceTable);
         ERDiagramEditPart.setUpdateable(true);
         relationship.setTargetTableView(targetTable, foreignKeyColumnList);
-        if (relationship.getWalkerSource() instanceof ERTable || relationship.getWalkerTarget() instanceof ERTable) {
-            final ERVirtualDiagramSet vdiagramSet = relationship.getWalkerSource().getDiagram().getDiagramContents().getVirtualDiagramSet();
+        if (relationship.getSourceWalker() instanceof ERTable || relationship.getTargetWalker() instanceof ERTable) {
+            final ERVirtualDiagramSet vdiagramSet = relationship.getSourceWalker().getDiagram().getDiagramContents().getVirtualDiagramSet();
             vdiagramSet.createRelationship(relationship);
         }
         final String foreignKeyName = provideDefaultForeignKeyName(sourceTable, targetTable);

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateSelfRelationshipCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateSelfRelationshipCommand.java
@@ -1,6 +1,7 @@
 package org.dbflute.erflute.editor.controller.command.diagram_contents.element.connection.relationship;
 
 import org.dbflute.erflute.editor.controller.editpart.element.ERDiagramEditPart;
+import org.dbflute.erflute.editor.model.ERModelUtil;
 import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Bendpoint;
 import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Relationship;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
@@ -27,7 +28,7 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
 
         boolean anotherSelfRelation = false;
 
-        final ERTable sourceTable = (ERTable) this.source.getModel();
+        final ERTable sourceTable = ((ERTable) source.getModel()).toMaterialize();
 
         for (final Relationship otherRelation : sourceTable.getOutgoingRelationshipList()) {
             if (otherRelation.getWalkerSource() == otherRelation.getWalkerTarget()) {
@@ -40,7 +41,6 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
 
         if (anotherSelfRelation) {
             rate = 50;
-
         } else {
             rate = 100;
         }
@@ -56,29 +56,27 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
 
         relation.addBendpoint(0, bendpoint0);
 
-        relation.setSourceWalker((ERTable) sourceTable);
+        relation.setSourceWalker(sourceTable);
 
         ERDiagramEditPart.setUpdateable(true);
 
-        relation.setTargetTableView((ERTable) this.target.getModel());
+        relation.setTargetTableView(((ERTable) target.getModel()).toMaterialize());
 
         sourceTable.setDirty();
+        ERModelUtil.refreshDiagram(sourceTable.getDiagram(), sourceTable);
     }
 
     @Override
     protected void doUndo() {
         ERDiagramEditPart.setUpdateable(false);
 
-        relation.setSourceWalker(null);
+        relation.delete(true, null);
 
         ERDiagramEditPart.setUpdateable(true);
 
-        relation.setTargetTableView(null);
-
-        this.relation.removeBendpoint(0);
-
-        final ERTable targetTable = (ERTable) this.target.getModel();
+        final ERTable targetTable = ((ERTable) target.getModel()).toMaterialize();
         targetTable.setDirty();
+        ERModelUtil.refreshDiagram(targetTable.getDiagram(), targetTable);
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateSelfRelationshipCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateSelfRelationshipCommand.java
@@ -8,7 +8,7 @@ import org.eclipse.gef.EditPart;
 
 public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCommand {
 
-    private Relationship relation;
+    private final Relationship relation;
 
     public CreateSelfRelationshipCommand(Relationship relation) {
         super();
@@ -19,7 +19,6 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
     public void setSource(EditPart source) {
         this.source = source;
         this.target = source;
-
     }
 
     @Override
@@ -28,9 +27,9 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
 
         boolean anotherSelfRelation = false;
 
-        ERTable sourceTable = (ERTable) this.source.getModel();
+        final ERTable sourceTable = (ERTable) this.source.getModel();
 
-        for (Relationship otherRelation : sourceTable.getOutgoingRelationshipList()) {
+        for (final Relationship otherRelation : sourceTable.getOutgoingRelationshipList()) {
             if (otherRelation.getWalkerSource() == otherRelation.getWalkerTarget()) {
                 anotherSelfRelation = true;
                 break;
@@ -46,11 +45,11 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
             rate = 100;
         }
 
-        Bendpoint bendpoint0 = new Bendpoint(rate, rate);
+        final Bendpoint bendpoint0 = new Bendpoint(rate, rate);
         bendpoint0.setRelative(true);
 
-        int xp = 100 - (rate / 2);
-        int yp = 100 - (rate / 2);
+        final int xp = 100 - (rate / 2);
+        final int yp = 100 - (rate / 2);
 
         relation.setSourceLocationp(100, yp);
         relation.setTargetLocationp(xp, 100);
@@ -78,7 +77,7 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
 
         this.relation.removeBendpoint(0);
 
-        ERTable targetTable = (ERTable) this.target.getModel();
+        final ERTable targetTable = (ERTable) this.target.getModel();
         targetTable.setDirty();
     }
 

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateSelfRelationshipCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/CreateSelfRelationshipCommand.java
@@ -31,7 +31,7 @@ public class CreateSelfRelationshipCommand extends AbstractCreateRelationshipCom
         final ERTable sourceTable = ((ERTable) source.getModel()).toMaterialize();
 
         for (final Relationship otherRelation : sourceTable.getOutgoingRelationshipList()) {
-            if (otherRelation.getWalkerSource() == otherRelation.getWalkerTarget()) {
+            if (otherRelation.getSourceWalker() == otherRelation.getTargetWalker()) {
                 anotherSelfRelation = true;
                 break;
             }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/ReconnectSourceCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/ReconnectSourceCommand.java
@@ -5,19 +5,14 @@ import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Rela
 
 public class ReconnectSourceCommand extends AbstractCommand {
 
-    private Relationship relation;
-
-    int xp;
-
-    int yp;
-
-    int oldXp;
-
-    int oldYp;
+    private final Relationship relation;
+    private final int xp;
+    private final int yp;
+    private int oldXp;
+    private int oldYp;
 
     public ReconnectSourceCommand(Relationship relation, int xp, int yp) {
         this.relation = relation;
-
         this.xp = xp;
         this.yp = yp;
     }
@@ -26,14 +21,13 @@ public class ReconnectSourceCommand extends AbstractCommand {
     protected void doExecute() {
         this.oldXp = relation.getSourceXp();
         this.oldYp = relation.getSourceYp();
-
-        relation.setSourceLocationp(this.xp, this.yp);
+        relation.setSourceLocationp(xp, yp);
         relation.setParentMove();
     }
 
     @Override
     protected void doUndo() {
-        relation.setSourceLocationp(this.oldXp, this.oldYp);
+        relation.setSourceLocationp(oldXp, oldYp);
         relation.setParentMove();
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/ReconnectTargetCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/connection/relationship/ReconnectTargetCommand.java
@@ -5,19 +5,14 @@ import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Rela
 
 public class ReconnectTargetCommand extends AbstractCommand {
 
-    private Relationship relation;
-
-    int xp;
-
-    int yp;
-
-    int oldXp;
-
-    int oldYp;
+    private final Relationship relation;
+    private final int xp;
+    private final int yp;
+    private int oldXp;
+    private int oldYp;
 
     public ReconnectTargetCommand(Relationship relation, int xp, int yp) {
         this.relation = relation;
-
         this.xp = xp;
         this.yp = yp;
     }
@@ -26,14 +21,13 @@ public class ReconnectTargetCommand extends AbstractCommand {
     protected void doExecute() {
         this.oldXp = relation.getTargetXp();
         this.oldYp = relation.getTargetYp();
-
-        relation.setTargetLocationp(this.xp, this.yp);
+        relation.setTargetLocationp(xp, yp);
         relation.setParentMove();
     }
 
     @Override
     protected void doUndo() {
-        relation.setTargetLocationp(this.oldXp, this.oldYp);
+        relation.setTargetLocationp(oldXp, oldYp);
         relation.setParentMove();
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/CreateElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/CreateElementCommand.java
@@ -8,7 +8,6 @@ import org.dbflute.erflute.editor.model.ERModelUtil;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.Location;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.category.Category;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.WalkerGroup;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.view.ERView;
@@ -68,23 +67,12 @@ public class CreateElementCommand extends AbstractCommand {
     //                                                                      ==============
     @Override
     protected void doExecute() {
-        final ERVirtualDiagram vdiagram = diagram.getCurrentVirtualDiagram();
         if (walker instanceof WalkerGroup) {
             final WalkerGroup group = (WalkerGroup) walker;
             group.setName("Your Group"); // as default
             group.setWalkers(enclosedWalkerList);
-            if (vdiagram != null) {
-                vdiagram.addWalkerGroup(group);
-            } else { // main diagram
-                diagram.addNewWalker(group);
-            }
-        } else { // e.g. table, note
-            if (vdiagram != null) {
-                vdiagram.addNewWalker(walker);
-            } else { // main diagram
-                diagram.addNewWalker(walker);
-            }
         }
+        diagram.addNewWalker(walker);
         ERModelUtil.refreshDiagram(diagram, walker);
     }
 

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/CreateElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/CreateElementCommand.java
@@ -29,6 +29,11 @@ public class CreateElementCommand extends AbstractCommand {
     // ===================================================================================
     //                                                                         Constructor
     //                                                                         ===========
+    public CreateElementCommand(ERDiagram diagram, DiagramWalker element, int x, int y, int width, int height,
+            List<DiagramWalker> enclosedElementList) {
+        this(diagram, element, x, y, new Dimension(width, height), enclosedElementList);
+    }
+
     public CreateElementCommand(ERDiagram diagram, DiagramWalker element, int x, int y, Dimension size,
             List<DiagramWalker> enclosedElementList) {
         this.diagram = diagram;

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/CreateElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/CreateElementCommand.java
@@ -79,7 +79,7 @@ public class CreateElementCommand extends AbstractCommand {
     @Override
     protected void doUndo() {
         if (!(walker instanceof Category)) {
-            diagram.removeContent(walker);
+            diagram.removeWalker(walker);
         } else {
             final Category category = (Category) walker;
             category.getContents().clear();

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
@@ -2,7 +2,6 @@ package org.dbflute.erflute.editor.controller.command.diagram_contents.element.n
 
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
 import org.dbflute.erflute.editor.model.ERDiagram;
-import org.dbflute.erflute.editor.model.ERModelUtil;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 
 /**
@@ -21,7 +20,6 @@ public class DeleteElementCommand extends AbstractCommand {
     @Override
     protected void doExecute() {
         diagram.removeContent(element);
-        ERModelUtil.refreshDiagram(diagram);
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
@@ -20,6 +20,8 @@ public class DeleteElementCommand extends AbstractCommand {
     @Override
     protected void doExecute() {
         diagram.removeContent(element);
+        // 以下コメントを外すと要素削除時、別要素の接続線が画面左上を指す不具合が発生する。
+        // ERModelUtil.refreshDiagram(diagram);
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
@@ -2,6 +2,7 @@ package org.dbflute.erflute.editor.controller.command.diagram_contents.element.n
 
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
 import org.dbflute.erflute.editor.model.ERDiagram;
+import org.dbflute.erflute.editor.model.ERModelUtil;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 
 /**
@@ -20,6 +21,7 @@ public class DeleteElementCommand extends AbstractCommand {
     @Override
     protected void doExecute() {
         diagram.removeContent(element);
+        ERModelUtil.refreshDiagram(diagram, element);
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
@@ -2,7 +2,6 @@ package org.dbflute.erflute.editor.controller.command.diagram_contents.element.n
 
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
 import org.dbflute.erflute.editor.model.ERDiagram;
-import org.dbflute.erflute.editor.model.ERModelUtil;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 
 /**
@@ -21,7 +20,6 @@ public class DeleteElementCommand extends AbstractCommand {
     @Override
     protected void doExecute() {
         diagram.removeContent(element);
-        ERModelUtil.refreshDiagram(diagram, element);
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/DeleteElementCommand.java
@@ -19,7 +19,7 @@ public class DeleteElementCommand extends AbstractCommand {
 
     @Override
     protected void doExecute() {
-        diagram.removeContent(element);
+        diagram.removeWalker(element);
         // 以下コメントを外すと要素削除時、別要素の接続線が画面左上を指す不具合が発生する。
         // ERModelUtil.refreshDiagram(diagram);
     }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/MoveElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/MoveElementCommand.java
@@ -7,42 +7,29 @@ import java.util.Map;
 
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
 import org.dbflute.erflute.editor.model.ERDiagram;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.Location;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
+import org.dbflute.erflute.editor.model.diagram_contents.element.node.Location;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.category.Category;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 public class MoveElementCommand extends AbstractCommand {
 
     protected int x;
-
     protected int oldX;
-
     protected int y;
-
     protected int oldY;
-
     protected int width;
-
     protected int oldWidth;
-
     protected int height;
-
     protected int oldHeight;
 
-    private DiagramWalker element;
-
-    private Map<Category, Rectangle> oldCategoryRectangleMap;
-
-    private Map<Category, Rectangle> newCategoryRectangleMap;
-
-    private List<Category> removedCategories;
-
-    private List<Category> addCategories;
-
-    private ERDiagram diagram;
-
-    private Rectangle bounds;
+    private final DiagramWalker element;
+    private final Map<Category, Rectangle> oldCategoryRectangleMap;
+    private final Map<Category, Rectangle> newCategoryRectangleMap;
+    private final List<Category> removedCategories;
+    private final List<Category> addCategories;
+    private final ERDiagram diagram;
+    private final Rectangle bounds;
 
     public MoveElementCommand(ERDiagram diagram, Rectangle bounds, int x, int y, int width, int height, DiagramWalker element) {
         this.element = element;
@@ -53,11 +40,11 @@ public class MoveElementCommand extends AbstractCommand {
         this.oldWidth = element.getWidth();
         this.oldHeight = element.getHeight();
 
-        this.oldCategoryRectangleMap = new HashMap<Category, Rectangle>();
-        this.newCategoryRectangleMap = new HashMap<Category, Rectangle>();
+        this.oldCategoryRectangleMap = new HashMap<>();
+        this.newCategoryRectangleMap = new HashMap<>();
 
-        this.removedCategories = new ArrayList<Category>();
-        this.addCategories = new ArrayList<Category>();
+        this.removedCategories = new ArrayList<>();
+        this.addCategories = new ArrayList<>();
 
         this.bounds = bounds;
         this.diagram = diagram;
@@ -71,15 +58,14 @@ public class MoveElementCommand extends AbstractCommand {
     }
 
     private void initCategory(ERDiagram diagram, Rectangle bounds) {
-
-        for (Category category : diagram.getDiagramContents().getSettings().getCategorySetting().getSelectedCategories()) {
+        for (final Category category : diagram.getDiagramContents().getSettings().getCategorySetting().getSelectedCategories()) {
             if (category.contains(element)) {
                 int categoryX = category.getX();
                 int categoryY = category.getY();
                 int categoryWidth = category.getWidth();
                 int categoryHeight = category.getHeight();
 
-                Rectangle oldRectangle = new Rectangle(categoryX, categoryY, categoryWidth, categoryHeight);
+                final Rectangle oldRectangle = new Rectangle(categoryX, categoryY, categoryWidth, categoryHeight);
 
                 boolean isDirty = false;
 
@@ -128,7 +114,7 @@ public class MoveElementCommand extends AbstractCommand {
     @Override
     protected void doExecute() {
         if (this.bounds != null) {
-            Rectangle rectangle = new Rectangle(bounds);
+            final Rectangle rectangle = new Rectangle(bounds);
 
             if (rectangle.x != x) {
                 rectangle.x = x;
@@ -146,16 +132,16 @@ public class MoveElementCommand extends AbstractCommand {
             this.initCategory(diagram, rectangle);
         }
 
-        for (Category category : this.newCategoryRectangleMap.keySet()) {
-            Rectangle rectangle = this.newCategoryRectangleMap.get(category);
+        for (final Category category : this.newCategoryRectangleMap.keySet()) {
+            final Rectangle rectangle = this.newCategoryRectangleMap.get(category);
             category.setLocation(new Location(rectangle.x, rectangle.y, rectangle.width, rectangle.height));
         }
 
-        for (Category category : removedCategories) {
+        for (final Category category : removedCategories) {
             category.getContents().remove(this.element);
         }
 
-        for (Category category : addCategories) {
+        for (final Category category : addCategories) {
             category.getContents().add(this.element);
         }
 
@@ -166,16 +152,16 @@ public class MoveElementCommand extends AbstractCommand {
     protected void doUndo() {
         this.element.setLocation(new Location(oldX, oldY, oldWidth, oldHeight));
 
-        for (Category category : this.oldCategoryRectangleMap.keySet()) {
-            Rectangle rectangle = this.oldCategoryRectangleMap.get(category);
+        for (final Category category : this.oldCategoryRectangleMap.keySet()) {
+            final Rectangle rectangle = this.oldCategoryRectangleMap.get(category);
             category.setLocation(new Location(rectangle.x, rectangle.y, rectangle.width, rectangle.height));
         }
 
-        for (Category category : removedCategories) {
+        for (final Category category : removedCategories) {
             category.getContents().add(this.element);
         }
 
-        for (Category category : addCategories) {
+        for (final Category category : addCategories) {
             category.getContents().remove(this.element);
         }
     }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceElementCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceElementCommand.java
@@ -6,8 +6,8 @@ import org.dbflute.erflute.core.DisplayMessages;
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
 import org.dbflute.erflute.editor.controller.editpart.element.AbstractModelEditPart;
 import org.dbflute.erflute.editor.model.ERDiagram;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.Location;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
+import org.dbflute.erflute.editor.model.diagram_contents.element.node.Location;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.category.Category;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.view.ERView;
@@ -15,14 +15,12 @@ import org.eclipse.draw2d.geometry.Dimension;
 
 public class PlaceElementCommand extends AbstractCommand {
 
-    private ERDiagram diagram;
-
-    private DiagramWalker element;
-
-    private List<DiagramWalker> enclosedElementList;
+    private final ERDiagram diagram;
+    private final DiagramWalker element;
+    private final List<DiagramWalker> enclosedElementList;
 
     /** Model or Diagram */
-    private AbstractModelEditPart editPart;
+    private final AbstractModelEditPart editPart;
 
     public PlaceElementCommand(ERDiagram diagram, AbstractModelEditPart editPart, DiagramWalker element, int x, int y, Dimension size,
             List<DiagramWalker> enclosedElementList) {
@@ -30,19 +28,19 @@ public class PlaceElementCommand extends AbstractCommand {
         this.element = element;
         this.editPart = editPart;
 
-        if (this.element instanceof Category && size != null) {
-            this.element.setLocation(new Location(x, y, size.width, size.height));
+        if (element instanceof Category && size != null) {
+            element.setLocation(new Location(x, y, size.width, size.height));
         } else {
-            this.element.setLocation(new Location(x, y, ERTable.DEFAULT_WIDTH, ERTable.DEFAULT_HEIGHT));
+            element.setLocation(new Location(x, y, ERTable.DEFAULT_WIDTH, ERTable.DEFAULT_HEIGHT));
         }
 
         if (element instanceof ERTable) {
-            ERTable table = (ERTable) element;
+            final ERTable table = (ERTable) element;
             table.setLogicalName(ERTable.NEW_LOGICAL_NAME);
             table.setPhysicalName(ERTable.NEW_PHYSICAL_NAME);
 
         } else if (element instanceof ERView) {
-            ERView view = (ERView) element;
+            final ERView view = (ERView) element;
             view.setLogicalName(ERView.NEW_LOGICAL_NAME);
             view.setPhysicalName(ERView.NEW_PHYSICAL_NAME);
         }
@@ -52,33 +50,31 @@ public class PlaceElementCommand extends AbstractCommand {
 
     @Override
     protected void doExecute() {
-        if (!(this.element instanceof Category)) {
-            this.diagram.addNewWalker(this.element);
-
+        if (!(element instanceof Category)) {
+            diagram.addNewWalker(element);
         } else {
-            Category category = (Category) this.element;
+            final Category category = (Category) element;
             category.setName(DisplayMessages.getMessage("label.category"));
-            category.setContents(this.enclosedElementList);
-            this.diagram.addCategory(category);
+            category.setContents(enclosedElementList);
+            diagram.addCategory(category);
         }
     }
 
     @Override
     protected void doUndo() {
-        if (!(this.element instanceof Category)) {
-            this.diagram.removeContent(this.element);
-
+        if (!(element instanceof Category)) {
+            diagram.removeWalker(element);
         } else {
-            Category category = (Category) this.element;
+            final Category category = (Category) element;
             category.getContents().clear();
-            this.diagram.removeCategory(category);
+            diagram.removeCategory(category);
         }
     }
 
     @Override
     public boolean canExecute() {
-        if (this.element instanceof Category) {
-            if (this.diagram.getCurrentCategory() != null) {
+        if (element instanceof Category) {
+            if (diagram.getCurrentCategory() != null) {
                 return false;
             }
         }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceTableCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceTableCommand.java
@@ -33,7 +33,6 @@ public class PlaceTableCommand extends AbstractCommand {
 
     @Override
     protected void doExecute() {
-
         if (orgTables != null) {
             // 複数配置
             final VirtualDiagramEditor modelEditor = (VirtualDiagramEditor) orgTables.get(0).getDiagram().getEditor().getActiveEditor();

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceTableCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceTableCommand.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 import org.dbflute.erflute.editor.VirtualDiagramEditor;
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
+import org.dbflute.erflute.editor.model.ERDiagram;
 import org.dbflute.erflute.editor.model.ERModelUtil;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERVirtualTable;
 import org.dbflute.erflute.editor.view.dialog.dbexport.ErrorDialog;
@@ -33,46 +33,43 @@ public class PlaceTableCommand extends AbstractCommand {
 
     @Override
     protected void doExecute() {
+        VirtualDiagramEditor editor;
         if (orgTables != null) {
             // 複数配置
-            final VirtualDiagramEditor modelEditor = (VirtualDiagramEditor) orgTables.get(0).getDiagram().getEditor().getActiveEditor();
+            editor = (VirtualDiagramEditor) orgTables.get(0).getDiagram().getEditor().getActiveEditor();
 
             final Point cursorLocation = Display.getCurrent().getCursorLocation();
-            final Point point = modelEditor.getGraphicalViewer().getControl().toControl(cursorLocation);
-            final FigureCanvas canvas = (FigureCanvas) modelEditor.getGraphicalViewer().getControl();
+            final Point point = editor.getGraphicalViewer().getControl().toControl(cursorLocation);
+            final FigureCanvas canvas = (FigureCanvas) editor.getGraphicalViewer().getControl();
             point.x += canvas.getHorizontalBar().getSelection();
             point.y += canvas.getVerticalBar().getSelection();
 
             virtualTables = new ArrayList<>();
             for (final ERTable curTable : orgTables) {
                 boolean cantPlace = false;
-                for (final ERVirtualTable vtable : modelEditor.getVirtualDiagram().getVirtualTables()) {
+                for (final ERVirtualTable vtable : editor.getVirtualDiagram().getVirtualTables()) {
                     if (vtable.getRawTable().equals(curTable)) {
                         cantPlace = true;
                     }
                 }
-                if (cantPlace)
+                if (cantPlace) {
                     continue;
+                }
 
-                final ERVirtualDiagram model = curTable.getDiagram().getCurrentVirtualDiagram();
-
-                virtualTable = new ERVirtualTable(model, curTable);
+                virtualTable = new ERVirtualTable(curTable.getDiagram().getCurrentVirtualDiagram(), curTable);
                 virtualTable.setPoint(point.x, point.y);
-                model.addTable(virtualTable);
-                virtualTables.add(virtualTable);
+                orgTables.get(0).getDiagram().addWalkerPlainly(virtualTable);
+
                 // 一つずつ右下にずらして配置
                 point.x += 32;
                 point.y += 32;
             }
-            ERModelUtil.refreshDiagram(modelEditor.getDiagram());
         } else {
-            final ERTable curTable = orgTable;
-
-            final VirtualDiagramEditor modelEditor = (VirtualDiagramEditor) curTable.getDiagram().getEditor().getActiveEditor();
+            editor = (VirtualDiagramEditor) orgTable.getDiagram().getEditor().getActiveEditor();
 
             // 既にビュー上に同一テーブルがあったら置けない
-            for (final ERVirtualTable vtable : modelEditor.getVirtualDiagram().getVirtualTables()) {
-                if (vtable.getRawTable().equals(curTable)) {
+            for (final ERVirtualTable vtable : editor.getVirtualDiagram().getVirtualTables()) {
+                if (vtable.getRawTable().equals(orgTable)) {
                     final ErrorDialog dialog = new ErrorDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
                             "既にこのテーブルはビューに配置されています。ビュー内に同一テーブルは一つしか置けません。");
                     dialog.open();
@@ -81,37 +78,35 @@ public class PlaceTableCommand extends AbstractCommand {
             }
 
             final Point cursorLocation = Display.getCurrent().getCursorLocation();
-            final Point point = modelEditor.getGraphicalViewer().getControl().toControl(cursorLocation);
-            final FigureCanvas canvas = (FigureCanvas) modelEditor.getGraphicalViewer().getControl();
+            final Point point = editor.getGraphicalViewer().getControl().toControl(cursorLocation);
+            final FigureCanvas canvas = (FigureCanvas) editor.getGraphicalViewer().getControl();
             point.x += canvas.getHorizontalBar().getSelection();
             point.y += canvas.getVerticalBar().getSelection();
 
-            final ERVirtualDiagram model = curTable.getDiagram().getCurrentVirtualDiagram();
-
-            virtualTable = new ERVirtualTable(model, curTable);
+            virtualTable = new ERVirtualTable(orgTable.getDiagram().getCurrentVirtualDiagram(), orgTable);
             virtualTable.setPoint(point.x, point.y);
-            model.addTable(virtualTable);
-            ERModelUtil.refreshDiagram(modelEditor.getDiagram());
+            orgTable.getDiagram().addWalkerPlainly(virtualTable);
         }
+
+        ERModelUtil.refreshDiagram(editor.getDiagram());
     }
 
     @Override
     protected void doUndo() {
         if (orgTables != null) {
-            final ERVirtualDiagram model = orgTables.get(0).getDiagram().getCurrentVirtualDiagram();
-
+            final ERDiagram diagram = orgTables.get(0).getDiagram();
             for (final ERVirtualTable vtable : virtualTables) {
-                model.remove(vtable);
+                diagram.removeContent(vtable);
             }
 
-            final VirtualDiagramEditor modelEditor = (VirtualDiagramEditor) orgTables.get(0).getDiagram().getEditor().getActiveEditor();
-            modelEditor.setContents(model);
+            final VirtualDiagramEditor editor = (VirtualDiagramEditor) diagram.getEditor().getActiveEditor();
+            editor.setContents(diagram.getCurrentVirtualDiagram());
         } else {
-            final ERVirtualDiagram model = orgTable.getDiagram().getCurrentVirtualDiagram();
-            model.remove(virtualTable);
+            final ERDiagram diagram = orgTable.getDiagram();
+            diagram.removeContent(virtualTable);
 
-            final VirtualDiagramEditor modelEditor = (VirtualDiagramEditor) orgTable.getDiagram().getEditor().getActiveEditor();
-            modelEditor.setContents(model);
+            final VirtualDiagramEditor editor = (VirtualDiagramEditor) diagram.getEditor().getActiveEditor();
+            editor.setContents(diagram.getCurrentVirtualDiagram());
         }
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceTableCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/PlaceTableCommand.java
@@ -96,14 +96,14 @@ public class PlaceTableCommand extends AbstractCommand {
         if (orgTables != null) {
             final ERDiagram diagram = orgTables.get(0).getDiagram();
             for (final ERVirtualTable vtable : virtualTables) {
-                diagram.removeContent(vtable);
+                diagram.removeWalker(vtable);
             }
 
             final VirtualDiagramEditor editor = (VirtualDiagramEditor) diagram.getEditor().getActiveEditor();
             editor.setContents(diagram.getCurrentVirtualDiagram());
         } else {
             final ERDiagram diagram = orgTable.getDiagram();
-            diagram.removeContent(virtualTable);
+            diagram.removeWalker(virtualTable);
 
             final VirtualDiagramEditor editor = (VirtualDiagramEditor) diagram.getEditor().getActiveEditor();
             editor.setContents(diagram.getCurrentVirtualDiagram());

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/group/MoveWalkerGroupCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/group/MoveWalkerGroupCommand.java
@@ -29,11 +29,11 @@ public class MoveWalkerGroupCommand extends MoveElementCommand {
             List<WalkerGroup> otherCategories, boolean move) {
         super(diagram, null, x, y, width, height, walkerGroup);
         this.walkerGroup = walkerGroup;
-        this.walkerList = new ArrayList<DiagramWalker>(walkerGroup.getDiagramWalkerList());
+        this.walkerList = new ArrayList<>(walkerGroup.getDiagramWalkerList());
         this.move = move;
 
-        if (!this.move) {
-            for (final DiagramWalker walker : this.walkerList) {
+        if (!move) {
+            for (final DiagramWalker walker : walkerList) {
                 final int walkerX = walker.getX();
                 final int walkerY = walker.getY();
                 int walkerWidth = walker.getWidth();
@@ -53,12 +53,12 @@ public class MoveWalkerGroupCommand extends MoveElementCommand {
                     height = walkerY - y + walkerHeight;
                 }
             }
-            this.setNewRectangle(x, y, width, height);
+            setNewRectangle(x, y, width, height);
         } else {
-            this.walkerOldLocationMap = new HashMap<DiagramWalker, Rectangle>();
+            this.walkerOldLocationMap = new HashMap<>();
             this.diffX = x - walkerGroup.getX();
             this.diffY = y - walkerGroup.getY();
-            for (final Iterator<DiagramWalker> iter = this.walkerList.iterator(); iter.hasNext();) {
+            for (final Iterator<DiagramWalker> iter = walkerList.iterator(); iter.hasNext();) {
                 final DiagramWalker walker = iter.next();
                 for (final WalkerGroup otherCategory : otherCategories) {
                     if (otherCategory.contains(walker)) {
@@ -67,8 +67,8 @@ public class MoveWalkerGroupCommand extends MoveElementCommand {
                     }
                 }
             }
-            for (final DiagramWalker walker : this.walkerList) {
-                this.walkerOldLocationMap.put(walker, new Rectangle(walker.getX(), walker.getY(), walker.getWidth(), walker.getHeight()));
+            for (final DiagramWalker walker : walkerList) {
+                walkerOldLocationMap.put(walker, new Rectangle(walker.getX(), walker.getY(), walker.getWidth(), walker.getHeight()));
             }
         }
     }
@@ -76,7 +76,7 @@ public class MoveWalkerGroupCommand extends MoveElementCommand {
     @Override
     protected void doExecute() {
         if (move) {
-            bendpointListMap = new HashMap<WalkerConnection, List<Bendpoint>>();
+            bendpointListMap = new HashMap<>();
             for (final DiagramWalker walker : walkerList) {
                 final Location location = new Location(walker.getX() + diffX, walker.getY() + diffY, walker.getWidth(), walker.getHeight());
                 walker.setLocation(location);
@@ -88,28 +88,28 @@ public class MoveWalkerGroupCommand extends MoveElementCommand {
 
     @Override
     protected void doUndo() {
-        if (this.move) {
-            for (final DiagramWalker nodeElement : this.walkerList) {
-                final Rectangle rectangle = this.walkerOldLocationMap.get(nodeElement);
+        if (move) {
+            for (final DiagramWalker nodeElement : walkerList) {
+                final Rectangle rectangle = walkerOldLocationMap.get(nodeElement);
                 nodeElement.setLocation(new Location(rectangle.x, rectangle.y, rectangle.width, rectangle.height));
             }
-            this.restoreBendpoints();
+            restoreBendpoints();
         }
         super.doUndo();
     }
 
     private void moveBendpoints(DiagramWalker source) {
         for (final WalkerConnection connectionElement : source.getOutgoings()) {
-            final DiagramWalker target = connectionElement.getWalkerTarget();
-            if (this.walkerGroup.contains(target)) {
+            final DiagramWalker target = connectionElement.getTargetWalker();
+            if (walkerGroup.contains(target)) {
                 final List<Bendpoint> bendpointList = connectionElement.getBendpoints();
-                final List<Bendpoint> oldBendpointList = new ArrayList<Bendpoint>();
+                final List<Bendpoint> oldBendpointList = new ArrayList<>();
                 for (int index = 0; index < bendpointList.size(); index++) {
                     final Bendpoint oldBendPoint = bendpointList.get(index);
                     if (oldBendPoint.isRelative()) {
                         break;
                     }
-                    final Bendpoint newBendpoint = new Bendpoint(oldBendPoint.getX() + this.diffX, oldBendPoint.getY() + this.diffY);
+                    final Bendpoint newBendpoint = new Bendpoint(oldBendPoint.getX() + diffX, oldBendPoint.getY() + diffY);
                     connectionElement.replaceBendpoint(index, newBendpoint);
                     oldBendpointList.add(oldBendPoint);
                 }
@@ -119,8 +119,8 @@ public class MoveWalkerGroupCommand extends MoveElementCommand {
     }
 
     private void restoreBendpoints() {
-        for (final WalkerConnection connectionElement : this.bendpointListMap.keySet()) {
-            final List<Bendpoint> oldBendpointList = this.bendpointListMap.get(connectionElement);
+        for (final WalkerConnection connectionElement : bendpointListMap.keySet()) {
+            final List<Bendpoint> oldBendpointList = bendpointListMap.get(connectionElement);
             for (int index = 0; index < oldBendpointList.size(); index++) {
                 connectionElement.replaceBendpoint(index, oldBendpointList.get(index));
             }

--- a/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/table_view/ChangeTableViewPropertyCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/diagram_contents/element/node/table_view/ChangeTableViewPropertyCommand.java
@@ -1,7 +1,6 @@
 package org.dbflute.erflute.editor.controller.command.diagram_contents.element.node.table_view;
 
 import org.dbflute.erflute.editor.controller.command.AbstractCommand;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERVirtualTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.TableView;
 
 public class ChangeTableViewPropertyCommand extends AbstractCommand {
@@ -20,49 +19,11 @@ public class ChangeTableViewPropertyCommand extends AbstractCommand {
 
     @Override
     protected void doExecute() {
-        if (tableView instanceof ERVirtualTable) {
-            final ERVirtualTable vtable = (ERVirtualTable) tableView;
-
-            // メインビューを更新（枠の再生成）
-            this.newCopyTableView.restructureData(vtable.getRawTable());
-            // TableView.firePropertyChange(PROPERTY_CHANGE_COLUMNS, null, null);
-
-            // サブビューも更新
-            vtable.changeTable();
-
-            // テーブルの更新（線も含めた再生成）
-            this.tableView.getDiagram().changeTable(newCopyTableView);
-        } else {
-            // メインビューを更新
-            this.newCopyTableView.restructureData(tableView);
-            this.tableView.getDiagram().changeTable(newCopyTableView);
-
-            // サブビューも更新
-            tableView.getDiagram().doChangeTable(newCopyTableView);
-        }
+        tableView.changeTableViewProperty(newCopyTableView);
     }
 
     @Override
     protected void doUndo() {
-        if (tableView instanceof ERVirtualTable) {
-            final ERVirtualTable vtable = (ERVirtualTable) tableView;
-
-            // メインビューを更新（枠の再生成）
-            this.oldCopyTableView.restructureData(vtable.getRawTable());
-            // TableView.firePropertyChange(PROPERTY_CHANGE_COLUMNS, null, null);
-
-            // サブビューも更新
-            vtable.changeTable();
-
-            // テーブルの更新（線も含めた再生成）
-            this.tableView.getDiagram().changeTable(oldCopyTableView);
-        } else {
-            // メインビューを更新
-            this.oldCopyTableView.restructureData(tableView);
-            this.tableView.getDiagram().changeTable(oldCopyTableView);
-
-            // サブビューも更新
-            tableView.getDiagram().doChangeTable(oldCopyTableView);
-        }
+        tableView.changeTableViewProperty(oldCopyTableView);
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/command/ermodel/AddVirtualDiagramCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/ermodel/AddVirtualDiagramCommand.java
@@ -21,7 +21,7 @@ public class AddVirtualDiagramCommand extends AbstractCommand {
     protected void doExecute() {
         final ERVirtualDiagram vdiagram = new ERVirtualDiagram(diagram);
         vdiagram.setName(name);
-        diagram.setCurrentVirtualDiagram(vdiagram, name);
+        diagram.setCurrentVirtualDiagram(vdiagram);
         diagram.addVirtualDiagram(vdiagram);
     }
 

--- a/src/org/dbflute/erflute/editor/controller/command/ermodel/ChangeVirtualDiagramNameCommand.java
+++ b/src/org/dbflute/erflute/editor/controller/command/ermodel/ChangeVirtualDiagramNameCommand.java
@@ -1,0 +1,42 @@
+package org.dbflute.erflute.editor.controller.command.ermodel;
+
+import org.dbflute.erflute.editor.controller.command.AbstractCommand;
+import org.dbflute.erflute.editor.model.ERDiagram;
+import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
+
+public class ChangeVirtualDiagramNameCommand extends AbstractCommand {
+
+    private final ERVirtualDiagram virtualDiagram;
+    private final String oldName;
+    private final String newName;
+
+    public ChangeVirtualDiagramNameCommand(ERVirtualDiagram virtualDiagram, String newName) {
+        this.virtualDiagram = virtualDiagram;
+        this.oldName = virtualDiagram.getName();
+        this.newName = newName;
+    }
+
+    private ERDiagram getDiagram() {
+        return virtualDiagram.getDiagram();
+    }
+
+    @Override
+    protected void doExecute() {
+        virtualDiagram.setName(newName);
+        getDiagram().getDiagramContents().getVirtualDiagramSet().changeVdiagram(virtualDiagram);
+
+        if (virtualDiagram.getDiagram().getCurrentVirtualDiagram() == virtualDiagram) {
+            virtualDiagram.getDiagram().getEditor().setPageText(newName);
+        }
+    }
+
+    @Override
+    protected void doUndo() {
+        virtualDiagram.setName(oldName);
+        getDiagram().getDiagramContents().getVirtualDiagramSet().changeVdiagram(virtualDiagram);
+
+        if (virtualDiagram.getDiagram().getCurrentVirtualDiagram() == virtualDiagram) {
+            virtualDiagram.getDiagram().getEditor().setPageText(oldName);
+        }
+    }
+}

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/connection/CommentConnectionEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/connection/CommentConnectionEditPart.java
@@ -39,34 +39,34 @@ public class CommentConnectionEditPart extends ERDiagramConnectionEditPart {
 
     @Override
     protected void createEditPolicies() {
-        this.installEditPolicy(EditPolicy.CONNECTION_ENDPOINTS_ROLE, new ConnectionEndpointEditPolicy());
-        this.installEditPolicy(EditPolicy.CONNECTION_ROLE, new CommentConnectionEditPolicy());
-        this.installEditPolicy(EditPolicy.CONNECTION_BENDPOINTS_ROLE, new ERDiagramBendpointEditPolicy());
+        installEditPolicy(EditPolicy.CONNECTION_ENDPOINTS_ROLE, new ConnectionEndpointEditPolicy());
+        installEditPolicy(EditPolicy.CONNECTION_ROLE, new CommentConnectionEditPolicy());
+        installEditPolicy(EditPolicy.CONNECTION_BENDPOINTS_ROLE, new ERDiagramBendpointEditPolicy());
     }
 
     @Override
     protected void refreshBendpoints() {
         // ベンド・ポイントの位置情報の取得
-        final WalkerConnection connection = (WalkerConnection) this.getModel();
+        final WalkerConnection connection = (WalkerConnection) getModel();
 
         // 実際のベンド・ポイントのリスト
-        final List<org.eclipse.draw2d.Bendpoint> constraint = new ArrayList<org.eclipse.draw2d.Bendpoint>();
+        final List<org.eclipse.draw2d.Bendpoint> constraint = new ArrayList<>();
 
         for (final Bendpoint bendPoint : connection.getBendpoints()) {
             constraint.add(new AbsoluteBendpoint(bendPoint.getX(), bendPoint.getY()));
         }
-        this.getConnectionFigure().setRoutingConstraint(constraint);
+        getConnectionFigure().setRoutingConstraint(constraint);
     }
 
     @Override
     public void performRequest(Request request) {
-        final Relationship relation = (Relationship) this.getModel();
+        final Relationship relation = (Relationship) getModel();
         if (request.getType().equals(RequestConstants.REQ_OPEN)) {
             final Relationship copy = relation.copy();
             final RelationshipDialog dialog = new RelationshipDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), copy);
             if (dialog.open() == IDialogConstants.OK_ID) {
                 final ChangeRelationshipPropertyCommand command = new ChangeRelationshipPropertyCommand(relation, copy);
-                this.getViewer().getEditDomain().getCommandStack().execute(command);
+                getViewer().getEditDomain().getCommandStack().execute(command);
             }
         }
         super.performRequest(request);

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/connection/CommentConnectionEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/connection/CommentConnectionEditPart.java
@@ -3,25 +3,18 @@ package org.dbflute.erflute.editor.controller.editpart.element.connection;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.dbflute.erflute.editor.controller.command.diagram_contents.element.connection.relationship.ChangeRelationshipPropertyCommand;
 import org.dbflute.erflute.editor.controller.editpolicy.element.connection.CommentConnectionEditPolicy;
 import org.dbflute.erflute.editor.controller.editpolicy.element.connection.ERDiagramBendpointEditPolicy;
 import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Bendpoint;
-import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Relationship;
 import org.dbflute.erflute.editor.model.diagram_contents.element.connection.WalkerConnection;
-import org.dbflute.erflute.editor.view.dialog.relationship.RelationshipDialog;
 import org.dbflute.erflute.editor.view.figure.connection.ERDiagramConnection;
 import org.eclipse.draw2d.AbsoluteBendpoint;
 import org.eclipse.draw2d.BendpointConnectionRouter;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.gef.EditPolicy;
-import org.eclipse.gef.Request;
-import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.editpolicies.ConnectionEndpointEditPolicy;
-import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;
-import org.eclipse.ui.PlatformUI;
 
 /**
  * @author modified by jflute (originated in ermaster)
@@ -56,19 +49,5 @@ public class CommentConnectionEditPart extends ERDiagramConnectionEditPart {
             constraint.add(new AbsoluteBendpoint(bendPoint.getX(), bendPoint.getY()));
         }
         getConnectionFigure().setRoutingConstraint(constraint);
-    }
-
-    @Override
-    public void performRequest(Request request) {
-        final Relationship relation = (Relationship) getModel();
-        if (request.getType().equals(RequestConstants.REQ_OPEN)) {
-            final Relationship copy = relation.copy();
-            final RelationshipDialog dialog = new RelationshipDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), copy);
-            if (dialog.open() == IDialogConstants.OK_ID) {
-                final ChangeRelationshipPropertyCommand command = new ChangeRelationshipPropertyCommand(relation, copy);
-                getViewer().getEditDomain().getCommandStack().execute(command);
-            }
-        }
-        super.performRequest(request);
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/connection/ERDiagramConnectionEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/connection/ERDiagramConnectionEditPart.java
@@ -61,13 +61,18 @@ public abstract class ERDiagramConnectionEditPart extends AbstractConnectionEdit
     @Override
     protected void refreshVisuals() {
         if (getDiagram() != null) {
+            if (getModel().isDeleted()) {
+                getFigure().setVisible(false);
+                return;
+            }
+
             final ERVirtualDiagram vdiagram = getDiagram().getCurrentVirtualDiagram();
-            final EditPart sourceEditPart = getSource();
-            final EditPart targetEditPart = getTarget();
+            final EditPart source = getSource();
+            final EditPart target = getTarget();
             if (vdiagram != null) {
                 // 仮想ダイアグラム上にソースとターゲットがない接続線は、非表示にする。
-                if (sourceEditPart != null && vdiagram.contains(sourceEditPart.getModel())
-                        && targetEditPart != null && vdiagram.contains(targetEditPart.getModel())) {
+                if (source != null && target != null
+                        && vdiagram.contains(source.getModel(), target.getModel())) {
                     getFigure().setVisible(true);
                 } else {
                     getFigure().setVisible(false);

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/connection/ERDiagramConnectionEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/connection/ERDiagramConnectionEditPart.java
@@ -60,29 +60,24 @@ public abstract class ERDiagramConnectionEditPart extends AbstractConnectionEdit
 
     @Override
     protected void refreshVisuals() {
-        if (getModel().isDeleted()) {
-            figure.setVisible(false);
-            return;
-        }
-
         if (getDiagram() != null) {
             final ERVirtualDiagram vdiagram = getDiagram().getCurrentVirtualDiagram();
             final EditPart sourceEditPart = getSource();
             final EditPart targetEditPart = getTarget();
             if (vdiagram != null) {
+                // 仮想ダイアグラム上にソースとターゲットがない接続線は、非表示にする。
                 if (sourceEditPart != null && vdiagram.contains(sourceEditPart.getModel())
                         && targetEditPart != null && vdiagram.contains(targetEditPart.getModel())) {
-                    figure.setVisible(true);
-                    return;
+                    getFigure().setVisible(true);
                 } else {
-                    figure.setVisible(false);
-                    return;
+                    getFigure().setVisible(false);
                 }
+                return;
             }
 
-            figure.setVisible(true);
+            getFigure().setVisible(true);
         } else {
-            figure.setVisible(false);
+            getFigure().setVisible(false);
         }
     }
 

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/connection/RelationEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/connection/RelationEditPart.java
@@ -42,7 +42,7 @@ public class RelationEditPart extends ERDiagramConnectionEditPart {
 
     @Override
     protected IFigure createFigure() {
-        final boolean bezier = this.getDiagram().getDiagramContents().getSettings().isUseBezierCurve();
+        final boolean bezier = getDiagram().getDiagramContents().getSettings().isUseBezierCurve();
         final PolylineConnection connection = new ERDiagramConnection(bezier);
         connection.setConnectionRouter(new BendpointConnectionRouter());
         final ConnectionEndpointLocator targetLocator = new ConnectionEndpointLocator(connection, true);
@@ -53,23 +53,23 @@ public class RelationEditPart extends ERDiagramConnectionEditPart {
 
     @Override
     protected void createEditPolicies() {
-        this.installEditPolicy(EditPolicy.CONNECTION_ENDPOINTS_ROLE, new ConnectionEndpointEditPolicy());
-        this.installEditPolicy(EditPolicy.CONNECTION_ROLE, new RelationEditPolicy());
-        this.installEditPolicy(EditPolicy.CONNECTION_BENDPOINTS_ROLE, new RelationBendpointEditPolicy());
+        installEditPolicy(EditPolicy.CONNECTION_ENDPOINTS_ROLE, new ConnectionEndpointEditPolicy());
+        installEditPolicy(EditPolicy.CONNECTION_ROLE, new RelationEditPolicy());
+        installEditPolicy(EditPolicy.CONNECTION_BENDPOINTS_ROLE, new RelationBendpointEditPolicy());
     }
 
     @Override
     protected void refreshBendpoints() {
         try {
             // ベンド・ポイントの位置情報の取得
-            final Relationship relation = (Relationship) this.getModel();
+            final Relationship relation = (Relationship) getModel();
 
             // 実際のベンド・ポイントのリスト
-            final List<org.eclipse.draw2d.Bendpoint> constraint = new ArrayList<org.eclipse.draw2d.Bendpoint>();
+            final List<org.eclipse.draw2d.Bendpoint> constraint = new ArrayList<>();
 
             for (final Bendpoint bendPoint : relation.getBendpoints()) {
                 if (bendPoint.isRelative()) {
-                    final ERTableEditPart tableEditPart = (ERTableEditPart) this.getSource();
+                    final ERTableEditPart tableEditPart = (ERTableEditPart) getSource();
                     if (tableEditPart != null) {
                         Rectangle bounds = tableEditPart.getFigure().getBounds();
                         int width = bounds.width;
@@ -89,30 +89,34 @@ public class RelationEditPart extends ERDiagramConnectionEditPart {
                         } else {
                             x = bounds.x + (bounds.width * xp / 100);
                         }
-                        point.setRelativeDimensions(new Dimension(width * bendPoint.getX() / 100 - bounds.x - bounds.width + x, 0),
+                        point.setRelativeDimensions(
+                                new Dimension(width * bendPoint.getX() / 100 - bounds.x - bounds.width + x, 0),
                                 new Dimension(width * bendPoint.getX() / 100 - bounds.x - bounds.width + x, 0));
                         point.setWeight(0);
-                        point.setConnection(this.getConnectionFigure());
+                        point.setConnection(getConnectionFigure());
                         constraint.add(point);
                         point = new RelativeBendpoint();
-                        point.setRelativeDimensions(new Dimension(width * bendPoint.getX() / 100 - bounds.x - bounds.width + x, height
-                                * bendPoint.getY() / 100), new Dimension(width * bendPoint.getX() / 100 - bounds.x - bounds.width + x,
-                                height * bendPoint.getY() / 100));
+                        point.setRelativeDimensions(
+                                new Dimension(width * bendPoint.getX() / 100 - bounds.x - bounds.width + x,
+                                        height * bendPoint.getY() / 100),
+                                new Dimension(width * bendPoint.getX() / 100 - bounds.x - bounds.width + x,
+                                        height * bendPoint.getY() / 100));
                         point.setWeight(0);
-                        point.setConnection(this.getConnectionFigure());
+                        point.setConnection(getConnectionFigure());
                         constraint.add(point);
                         point = new RelativeBendpoint();
-                        point.setRelativeDimensions(new Dimension(x - bounds.x - bounds.width, height * bendPoint.getY() / 100),
+                        point.setRelativeDimensions(
+                                new Dimension(x - bounds.x - bounds.width, height * bendPoint.getY() / 100),
                                 new Dimension(x - bounds.x - bounds.width, height * bendPoint.getY() / 100));
                         point.setWeight(0);
-                        point.setConnection(this.getConnectionFigure());
+                        point.setConnection(getConnectionFigure());
                         constraint.add(point);
                     }
                 } else {
                     constraint.add(new AbsoluteBendpoint(bendPoint.getX(), bendPoint.getY()));
                 }
             }
-            this.getConnectionFigure().setRoutingConstraint(constraint);
+            getConnectionFigure().setRoutingConstraint(constraint);
         } catch (final Exception e) {
             Activator.showExceptionDialog(e);
         }
@@ -121,10 +125,10 @@ public class RelationEditPart extends ERDiagramConnectionEditPart {
     @Override
     protected void refreshVisuals() {
         super.refreshVisuals();
-        final ERDiagram diagram = this.getDiagram();
+        final ERDiagram diagram = getDiagram();
         if (diagram != null) {
-            final Relationship relation = (Relationship) this.getModel();
-            final PolylineConnection connection = (PolylineConnection) this.getConnectionFigure();
+            final Relationship relation = (Relationship) getModel();
+            final PolylineConnection connection = (PolylineConnection) getConnectionFigure();
             final String notation = diagram.getDiagramContents().getSettings().getNotation();
             final Decoration decoration =
                     DecorationFactory.getDecoration(notation, relation.getParentCardinality(), relation.getChildCardinality());
@@ -132,47 +136,45 @@ public class RelationEditPart extends ERDiagramConnectionEditPart {
             connection.setTargetDecoration(decoration.getTargetDecoration());
             targetLabel.setText(Format.null2blank(decoration.getTargetLabel()));
         }
-        this.calculateAnchorLocation();
-        this.refreshBendpoints();
+        calculateAnchorLocation();
+        refreshBendpoints();
     }
 
     @Override
     public void performRequest(Request request) {
-        final Relationship relation = (Relationship) this.getModel();
+        final Relationship relation = (Relationship) getModel();
         if (request.getType().equals(RequestConstants.REQ_OPEN)) {
             final Relationship copy = relation.copy();
             final RelationshipDialog dialog = new RelationshipDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), copy);
             if (dialog.open() == IDialogConstants.OK_ID) {
                 final ChangeRelationshipPropertyCommand command = new ChangeRelationshipPropertyCommand(relation, copy);
-                this.getViewer().getEditDomain().getCommandStack().execute(command);
+                getViewer().getEditDomain().getCommandStack().execute(command);
             }
         }
         super.performRequest(request);
     }
 
     private void calculateAnchorLocation() {
-        final Relationship relation = (Relationship) this.getModel();
-        final TableViewEditPart sourceEditPart = (TableViewEditPart) this.getSource();
+        final Relationship relation = (Relationship) getModel();
+        final TableViewEditPart sourceEditPart = (TableViewEditPart) getSource();
         Point sourcePoint = null;
         Point targetPoint = null;
         if (sourceEditPart != null && relation.getSourceXp() != -1 && relation.getSourceYp() != -1) {
             final Rectangle bounds = sourceEditPart.getFigure().getBounds();
-            sourcePoint =
-                    new Point(bounds.x + (bounds.width * relation.getSourceXp() / 100), bounds.y
-                            + (bounds.height * relation.getSourceYp() / 100));
+            sourcePoint = new Point(bounds.x + (bounds.width * relation.getSourceXp() / 100),
+                    bounds.y + (bounds.height * relation.getSourceYp() / 100));
         }
-        final TableViewEditPart targetEditPart = (TableViewEditPart) this.getTarget();
+        final TableViewEditPart targetEditPart = (TableViewEditPart) getTarget();
         if (targetEditPart != null && relation.getTargetXp() != -1 && relation.getTargetYp() != -1) {
             final Rectangle bounds = targetEditPart.getFigure().getBounds();
-            targetPoint =
-                    new Point(bounds.x + (bounds.width * relation.getTargetXp() / 100), bounds.y
-                            + (bounds.height * relation.getTargetYp() / 100));
+            targetPoint = new Point(bounds.x + (bounds.width * relation.getTargetXp() / 100),
+                    bounds.y + (bounds.height * relation.getTargetYp() / 100));
         }
-        final ConnectionAnchor sourceAnchor = this.getConnectionFigure().getSourceAnchor();
+        final ConnectionAnchor sourceAnchor = getConnectionFigure().getSourceAnchor();
         if (sourceAnchor instanceof XYChopboxAnchor) {
             ((XYChopboxAnchor) sourceAnchor).setLocation(sourcePoint);
         }
-        final ConnectionAnchor targetAnchor = this.getConnectionFigure().getTargetAnchor();
+        final ConnectionAnchor targetAnchor = getConnectionFigure().getTargetAnchor();
         if (targetAnchor instanceof XYChopboxAnchor) {
             ((XYChopboxAnchor) targetAnchor).setLocation(targetPoint);
         }

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/node/ERVirtualDiagramEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/node/ERVirtualDiagramEditPart.java
@@ -29,7 +29,7 @@ public class ERVirtualDiagramEditPart extends DiagramWalkerEditPart {
             // ?
         } else if (event.getPropertyName().equals(ViewableModel.PROPERTY_CHANGE_COLOR)) {
             refreshVisuals();
-        } else if (event.getPropertyName().equals(ERVirtualDiagram.REMOVE_VCONTENT)) {
+        } else if (event.getPropertyName().equals(ERVirtualDiagram.REMOVE_VWALKER)) {
             refreshRelations();
             refreshChildren();
             refresh();

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/node/ERVirtualDiagramEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/node/ERVirtualDiagramEditPart.java
@@ -29,6 +29,10 @@ public class ERVirtualDiagramEditPart extends DiagramWalkerEditPart {
             // ?
         } else if (event.getPropertyName().equals(ViewableModel.PROPERTY_CHANGE_COLOR)) {
             refreshVisuals();
+        } else if (event.getPropertyName().equals(ERVirtualDiagram.REMOVE_VCONTENT)) {
+            refreshRelations();
+            refreshChildren();
+            refresh();
         }
     }
 
@@ -56,7 +60,7 @@ public class ERVirtualDiagramEditPart extends DiagramWalkerEditPart {
 
     @Override
     protected void createEditPolicies() {
-        this.installEditPolicy(EditPolicy.LAYOUT_ROLE, new ERDiagramLayoutEditPolicy());
+        installEditPolicy(EditPolicy.LAYOUT_ROLE, new ERDiagramLayoutEditPolicy());
     }
 
     @Override
@@ -65,9 +69,9 @@ public class ERVirtualDiagramEditPart extends DiagramWalkerEditPart {
         final int[] color = element.getColor();
         if (color != null) {
             final Color bgColor = DesignResources.getColor(color);
-            this.getViewer().getControl().setBackground(bgColor);
+            getViewer().getControl().setBackground(bgColor);
         }
-        for (final Object child : this.getChildren()) {
+        for (final Object child : getChildren()) {
             if (child instanceof DiagramWalkerEditPart) {
                 final DiagramWalkerEditPart part = (DiagramWalkerEditPart) child;
                 part.refreshVisuals();

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/node/TableViewEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/node/TableViewEditPart.java
@@ -54,7 +54,7 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
 
     @Override
     protected List<Object> getModelChildren() {
-        final List<Object> modelChildren = new ArrayList<Object>();
+        final List<Object> modelChildren = new ArrayList<>();
         final TableView tableView = (TableView) getModel();
         final ERDiagram diagram = getDiagram();
         if (diagram.getDiagramContents().getSettings().isNotationExpandGroup()) {
@@ -84,7 +84,7 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
     }
 
     protected List<WalkerConnection> filterConnections(final List<WalkerConnection> connections) {
-        final List<WalkerConnection> filteredList = new ArrayList<WalkerConnection>();
+        final List<WalkerConnection> filteredList = new ArrayList<>();
         for (final WalkerConnection connection : connections) { // #for_erflute
             if (!isVirtualDiagram() && connection.isVirtualDiagramOnly()) { // e.g. note
                 continue;
@@ -105,32 +105,32 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
         } else if (event.getPropertyName().equals(TableView.PROPERTY_CHANGE_LOGICAL_NAME)) {
             refreshVisuals();
         } else if (event.getPropertyName().equals(TableView.PROPERTY_CHANGE_COLUMNS)) {
-            this.refreshChildren();
+            refreshChildren();
             refreshVisuals();
         }
         super.doPropertyChange(event);
-        this.refreshConnections();
+        refreshConnections();
     }
 
     @Override
     public void refresh() {
         super.refresh();
-        this.refreshConnections();
+        refreshConnections();
     }
 
     @Override
     public void refreshVisuals() {
         try {
-            final TableFigure tableFigure = (TableFigure) this.getFigure();
-            final TableView tableView = (TableView) this.getModel();
+            final TableFigure tableFigure = (TableFigure) getFigure();
+            final TableView tableView = (TableView) getModel();
             tableFigure.create(tableView.getColor());
-            final ERDiagram diagram = this.getDiagram();
+            final ERDiagram diagram = getDiagram();
             tableFigure.setName(getTableViewName(tableView, diagram));
-            final List childrens = this.getChildren();
+            final List childrens = getChildren();
             if (childrens == null || childrens.isEmpty()) {
                 refreshChildren();
             }
-            for (final Object child : this.getChildren()) {
+            for (final Object child : getChildren()) {
                 if (child instanceof ColumnEditPart) {
                     final ColumnEditPart part = (ColumnEditPart) child;
                     part.refreshTableColumns();
@@ -146,7 +146,7 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
             }
             super.refreshVisuals();
             if (ERDiagramEditPart.isUpdateable()) {
-                this.getFigure().getUpdateManager().performValidation();
+                getFigure().getUpdateManager().performValidation();
             }
         } catch (final Exception e) {
             Activator.showExceptionDialog(e);
@@ -161,14 +161,15 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
                 if (diagram.getDiagramContents().getSettings().isNotationExpandGroup()) {
                     final ColumnGroup columnGroup = (ColumnGroup) removedColumn;
                     for (final NormalColumn normalColumn : columnGroup.getColumns()) {
-                        if (notationLevel == DiagramSettings.NOTATION_LEVLE_KEY && !normalColumn.isPrimaryKey() && !normalColumn.isForeignKey()
+                        if (notationLevel == DiagramSettings.NOTATION_LEVLE_KEY && !normalColumn.isPrimaryKey()
+                                && !normalColumn.isForeignKey()
                                 && !normalColumn.isReferedStrictly()) {
                             continue;
                         }
                         final NormalColumnFigure columnFigure = new NormalColumnFigure();
                         tableFigure.getColumns().add(columnFigure);
-                        NormalColumnEditPart.addColumnFigure(diagram, table, tableFigure, columnFigure, normalColumn, false, false, false,
-                                false, isRemoved);
+                        NormalColumnEditPart.addColumnFigure(diagram, table, tableFigure,
+                                columnFigure, normalColumn, false, false, false, false, isRemoved);
                     }
                 } else {
                     if ((notationLevel == DiagramSettings.NOTATION_LEVLE_KEY)) {
@@ -186,8 +187,8 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
                 }
                 final NormalColumnFigure columnFigure = new NormalColumnFigure();
                 tableFigure.getColumns().add(columnFigure);
-                NormalColumnEditPart.addColumnFigure(diagram, table, tableFigure, columnFigure, normalColumn, false, false, false, false,
-                        isRemoved);
+                NormalColumnEditPart.addColumnFigure(diagram, table, tableFigure,
+                        columnFigure, normalColumn, false, false, false, false, isRemoved);
             }
         }
     }
@@ -209,27 +210,21 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
 
     protected Font changeFont(TableFigure tableFigure) {
         final Font font = super.changeFont(tableFigure);
-
         final FontData fonData = font.getFontData()[0];
-
         this.titleFont = new Font(Display.getCurrent(), fonData.getName(), fonData.getHeight(), SWT.BOLD);
 
-        tableFigure.setFont(font, this.titleFont);
+        tableFigure.setFont(font, titleFont);
 
         return font;
     }
 
     public static String getTableViewName(TableView tableView, ERDiagram diagram) {
-        String name = null;
-
         final int viewMode = diagram.getDiagramContents().getSettings().getViewMode();
-
+        String name = null;
         if (viewMode == DiagramSettings.VIEW_MODE_PHYSICAL) {
             name = diagram.filter(tableView.getPhysicalName());
-
         } else if (viewMode == DiagramSettings.VIEW_MODE_LOGICAL) {
             name = diagram.filter(tableView.getLogicalName());
-
         } else {
             name = diagram.filter(tableView.getLogicalName()) + " / " + diagram.filter(tableView.getPhysicalName());
         }
@@ -244,14 +239,11 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
         }
 
         final Relationship relation = (Relationship) editPart.getModel();
-
-        final Rectangle bounds = this.getFigure().getBounds();
-
-        final XYChopboxAnchor anchor = new XYChopboxAnchor(this.getFigure());
-
+        final Rectangle bounds = getFigure().getBounds();
+        final XYChopboxAnchor anchor = new XYChopboxAnchor(getFigure());
         if (relation.getSourceXp() != -1 && relation.getSourceYp() != -1) {
-            anchor.setLocation(new Point(bounds.x + (bounds.width * relation.getSourceXp() / 100), bounds.y
-                    + (bounds.height * relation.getSourceYp() / 100)));
+            anchor.setLocation(new Point(bounds.x + (bounds.width * relation.getSourceXp() / 100),
+                    bounds.y + (bounds.height * relation.getSourceYp() / 100)));
         }
 
         return anchor;
@@ -261,53 +253,45 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
     public ConnectionAnchor getSourceConnectionAnchor(Request request) {
         if (request instanceof ReconnectRequest) {
             final ReconnectRequest reconnectRequest = (ReconnectRequest) request;
-
             final ConnectionEditPart connectionEditPart = reconnectRequest.getConnectionEditPart();
-
             if (!(connectionEditPart instanceof RelationEditPart)) {
                 return super.getSourceConnectionAnchor(request);
             }
 
             final Relationship relation = (Relationship) connectionEditPart.getModel();
-            if (relation.getWalkerSource() == relation.getWalkerTarget()) {
-                return new XYChopboxAnchor(this.getFigure());
+            if (relation.getSourceWalker() == relation.getTargetWalker()) {
+                return new XYChopboxAnchor(getFigure());
             }
 
             final EditPart editPart = reconnectRequest.getTarget();
-
-            if (editPart == null || !editPart.getModel().equals(relation.getWalkerSource())) {
-                return new XYChopboxAnchor(this.getFigure());
+            if (editPart == null || !editPart.getModel().equals(relation.getSourceWalker())) {
+                return new XYChopboxAnchor(getFigure());
             }
 
             final Point location = new Point(reconnectRequest.getLocation());
-            this.getFigure().translateToRelative(location);
+            getFigure().translateToRelative(location);
+
             final IFigure sourceFigure = ((TableViewEditPart) connectionEditPart.getSource()).getFigure();
-
-            final XYChopboxAnchor anchor = new XYChopboxAnchor(this.getFigure());
-
             final Rectangle bounds = sourceFigure.getBounds();
-
             final Rectangle centerRectangle =
                     new Rectangle(bounds.x + (bounds.width / 4), bounds.y + (bounds.height / 4), bounds.width / 2, bounds.height / 2);
 
+            final XYChopboxAnchor anchor = new XYChopboxAnchor(getFigure());
             if (!centerRectangle.contains(location)) {
                 final Point point = getIntersectionPoint(location, sourceFigure);
                 anchor.setLocation(point);
             }
 
             return anchor;
-
         } else if (request instanceof CreateConnectionRequest) {
             final CreateConnectionRequest connectionRequest = (CreateConnectionRequest) request;
-
             final Command command = connectionRequest.getStartCommand();
-
             if (command instanceof CreateCommentConnectionCommand) {
                 return super.getTargetConnectionAnchor(request);
             }
         }
 
-        return new XYChopboxAnchor(this.getFigure());
+        return new XYChopboxAnchor(getFigure());
     }
 
     @Override
@@ -317,14 +301,11 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
         }
 
         final Relationship relation = (Relationship) editPart.getModel();
-
-        final XYChopboxAnchor anchor = new XYChopboxAnchor(this.getFigure());
-
-        final Rectangle bounds = this.getFigure().getBounds();
-
+        final XYChopboxAnchor anchor = new XYChopboxAnchor(getFigure());
+        final Rectangle bounds = getFigure().getBounds();
         if (relation.getTargetXp() != -1 && relation.getTargetYp() != -1) {
-            anchor.setLocation(new Point(bounds.x + (bounds.width * relation.getTargetXp() / 100), bounds.y
-                    + (bounds.height * relation.getTargetYp() / 100)));
+            anchor.setLocation(new Point(bounds.x + (bounds.width * relation.getTargetXp() / 100),
+                    bounds.y + (bounds.height * relation.getTargetYp() / 100)));
         }
 
         return anchor;
@@ -334,61 +315,52 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
     public ConnectionAnchor getTargetConnectionAnchor(Request request) {
         if (request instanceof ReconnectRequest) {
             final ReconnectRequest reconnectRequest = (ReconnectRequest) request;
-
             final ConnectionEditPart connectionEditPart = reconnectRequest.getConnectionEditPart();
-
             if (!(connectionEditPart instanceof RelationEditPart)) {
                 return super.getTargetConnectionAnchor(request);
             }
 
             final Relationship relation = (Relationship) connectionEditPart.getModel();
-            if (relation.getWalkerSource() == relation.getWalkerTarget()) {
-                return new XYChopboxAnchor(this.getFigure());
+            if (relation.getSourceWalker() == relation.getTargetWalker()) {
+                return new XYChopboxAnchor(getFigure());
             }
 
             final EditPart editPart = reconnectRequest.getTarget();
-
-            if (editPart == null || !editPart.getModel().equals(relation.getWalkerTarget())) {
-                return new XYChopboxAnchor(this.getFigure());
+            if (editPart == null || !editPart.getModel().equals(relation.getTargetWalker())) {
+                return new XYChopboxAnchor(getFigure());
             }
 
             final Point location = new Point(reconnectRequest.getLocation());
-            this.getFigure().translateToRelative(location);
+            getFigure().translateToRelative(location);
+
             final IFigure targetFigure = ((TableViewEditPart) connectionEditPart.getTarget()).getFigure();
-
-            final XYChopboxAnchor anchor = new XYChopboxAnchor(this.getFigure());
-
             final Rectangle bounds = targetFigure.getBounds();
-
             final Rectangle centerRectangle =
                     new Rectangle(bounds.x + (bounds.width / 4), bounds.y + (bounds.height / 4), bounds.width / 2, bounds.height / 2);
-
+            final XYChopboxAnchor anchor = new XYChopboxAnchor(getFigure());
             if (!centerRectangle.contains(location)) {
                 final Point point = getIntersectionPoint(location, targetFigure);
                 anchor.setLocation(point);
             }
 
             return anchor;
-
         } else if (request instanceof CreateConnectionRequest) {
             final CreateConnectionRequest connectionRequest = (CreateConnectionRequest) request;
-
             final Command command = connectionRequest.getStartCommand();
-
             if (command instanceof CreateCommentConnectionCommand) {
                 return super.getTargetConnectionAnchor(request);
             }
         }
 
-        return new XYChopboxAnchor(this.getFigure());
+        return new XYChopboxAnchor(getFigure());
     }
 
     public static Point getIntersectionPoint(Point s, IFigure figure) {
-
         final Rectangle r = figure.getBounds();
 
         final int x1 = s.x - r.x;
         final int x2 = r.x + r.width - s.x;
+
         final int y1 = s.y - r.y;
         final int y2 = r.y + r.height - s.y;
 
@@ -397,7 +369,6 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
         if (x1 < x2) {
             x = r.x;
             dx = x1;
-
         } else {
             x = r.x + r.width;
             dx = x2;
@@ -405,11 +376,9 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
 
         int y = 0;
         int dy = 0;
-
         if (y1 < y2) {
             y = r.y;
             dy = y1;
-
         } else {
             y = r.y + r.height;
             dy = y2;
@@ -427,13 +396,12 @@ public abstract class TableViewEditPart extends DiagramWalkerEditPart implements
     @Override
     public IFigure getContentPane() {
         final TableFigure figure = (TableFigure) super.getContentPane();
-
         return figure.getColumns();
     }
 
     @Override
     protected void createEditPolicies() {
-        this.installEditPolicy(EditPolicy.COMPONENT_ROLE, new TableViewComponentEditPolicy());
-        this.installEditPolicy(EditPolicy.GRAPHICAL_NODE_ROLE, new TableViewGraphicalNodeEditPolicy());
+        installEditPolicy(EditPolicy.COMPONENT_ROLE, new TableViewComponentEditPolicy());
+        installEditPolicy(EditPolicy.GRAPHICAL_NODE_ROLE, new TableViewGraphicalNodeEditPolicy());
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/node/WalkerNoteEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/node/WalkerNoteEditPart.java
@@ -4,6 +4,7 @@ import java.beans.PropertyChangeEvent;
 
 import org.dbflute.erflute.editor.controller.editpolicy.element.node.DiagramWalkerComponentEditPolicy;
 import org.dbflute.erflute.editor.controller.editpolicy.element.node.note.WalkerNoteDirectEditPolicy;
+import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.note.WalkerNote;
 import org.dbflute.erflute.editor.view.editmanager.WalkerNoteCellEditor;
 import org.dbflute.erflute.editor.view.editmanager.WalkerNoteEditManager;
@@ -29,6 +30,8 @@ public class WalkerNoteEditPart extends DiagramWalkerEditPart implements IResiza
     public void doPropertyChange(PropertyChangeEvent event) {
         if (event.getPropertyName().equals(WalkerNote.PROPERTY_CHANGE_WALKER_NOTE)) {
             refreshVisuals();
+        } else if (event.getPropertyName().equals(DiagramWalker.PROPERTY_CHANGE_OUTGOING)) {
+            refreshConnections();
         }
         super.doPropertyChange(event);
     }

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/node/WalkerNoteEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/node/WalkerNoteEditPart.java
@@ -4,7 +4,6 @@ import java.beans.PropertyChangeEvent;
 
 import org.dbflute.erflute.editor.controller.editpolicy.element.node.DiagramWalkerComponentEditPolicy;
 import org.dbflute.erflute.editor.controller.editpolicy.element.node.note.WalkerNoteDirectEditPolicy;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.note.WalkerNote;
 import org.dbflute.erflute.editor.view.editmanager.WalkerNoteCellEditor;
 import org.dbflute.erflute.editor.view.editmanager.WalkerNoteEditManager;
@@ -22,7 +21,7 @@ public class WalkerNoteEditPart extends DiagramWalkerEditPart implements IResiza
     @Override
     protected IFigure createFigure() {
         final WalkerNoteFigure noteFigure = new WalkerNoteFigure();
-        this.changeFont(noteFigure);
+        changeFont(noteFigure);
         return noteFigure;
     }
 
@@ -30,23 +29,21 @@ public class WalkerNoteEditPart extends DiagramWalkerEditPart implements IResiza
     public void doPropertyChange(PropertyChangeEvent event) {
         if (event.getPropertyName().equals(WalkerNote.PROPERTY_CHANGE_WALKER_NOTE)) {
             refreshVisuals();
-        } else if (event.getPropertyName().equals(DiagramWalker.PROPERTY_CHANGE_OUTGOING)) {
-            refreshConnections();
         }
         super.doPropertyChange(event);
     }
 
     @Override
     protected void createEditPolicies() {
-        this.installEditPolicy(EditPolicy.COMPONENT_ROLE, new DiagramWalkerComponentEditPolicy());
-        this.installEditPolicy(EditPolicy.DIRECT_EDIT_ROLE, new WalkerNoteDirectEditPolicy());
+        installEditPolicy(EditPolicy.COMPONENT_ROLE, new DiagramWalkerComponentEditPolicy());
+        installEditPolicy(EditPolicy.DIRECT_EDIT_ROLE, new WalkerNoteDirectEditPolicy());
         super.createEditPolicies();
     }
 
     @Override
     public void refreshVisuals() {
-        final WalkerNote note = (WalkerNote) this.getModel();
-        final WalkerNoteFigure figure = (WalkerNoteFigure) this.getFigure();
+        final WalkerNote note = (WalkerNote) getModel();
+        final WalkerNoteFigure figure = (WalkerNoteFigure) getFigure();
         figure.setText(note.getNoteText(), note.getColor());
         super.refreshVisuals();
     }
@@ -59,10 +56,10 @@ public class WalkerNoteEditPart extends DiagramWalkerEditPart implements IResiza
     }
 
     private void performDirectEdit() {
-        if (this.editManager == null) {
+        if (editManager == null) {
             this.editManager = new WalkerNoteEditManager(this, WalkerNoteCellEditor.class, new WalkerNoteEditorLocator(getFigure()));
         }
-        this.editManager.show();
+        editManager.show();
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/controller/editpart/element/node/WalkerNoteEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/element/node/WalkerNoteEditPart.java
@@ -29,6 +29,9 @@ public class WalkerNoteEditPart extends DiagramWalkerEditPart implements IResiza
     public void doPropertyChange(PropertyChangeEvent event) {
         if (event.getPropertyName().equals(WalkerNote.PROPERTY_CHANGE_WALKER_NOTE)) {
             refreshVisuals();
+        } else if (event.getPropertyName().equals(WalkerNote.PROPERTY_CHANGE_OUTGOING)) {
+            // ノート接続線削除を描画するため
+            refreshConnections();
         }
         super.doPropertyChange(event);
     }

--- a/src/org/dbflute/erflute/editor/controller/editpart/outline/table/RelationOutlineEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/outline/table/RelationOutlineEditPart.java
@@ -9,8 +9,8 @@ import org.dbflute.erflute.editor.controller.command.diagram_contents.element.co
 import org.dbflute.erflute.editor.controller.editpart.outline.AbstractOutlineEditPart;
 import org.dbflute.erflute.editor.controller.editpolicy.element.connection.RelationEditPolicy;
 import org.dbflute.erflute.editor.model.ERDiagram;
-import org.dbflute.erflute.editor.model.diagram_contents.element.connection.WalkerConnection;
 import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Relationship;
+import org.dbflute.erflute.editor.model.diagram_contents.element.connection.WalkerConnection;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.column.NormalColumn;
 import org.dbflute.erflute.editor.model.settings.DiagramSettings;
@@ -25,28 +25,24 @@ import org.eclipse.ui.PlatformUI;
 
 public class RelationOutlineEditPart extends AbstractOutlineEditPart {
 
+    @Override
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(ERTable.PROPERTY_CHANGE_PHYSICAL_NAME)) {
             refreshVisuals();
-
         } else if (evt.getPropertyName().equals(WalkerConnection.PROPERTY_CHANGE_CONNECTION_ATTRIBUTE)) {
             refreshVisuals();
-
         }
     }
 
     @Override
     protected void refreshOutlineVisuals() {
-        Relationship model = (Relationship) this.getModel();
-
-        ERDiagram diagram = (ERDiagram) this.getRoot().getContents().getModel();
-
-        int viewMode = diagram.getDiagramContents().getSettings().getOutlineViewMode();
+        final Relationship model = (Relationship) getModel();
+        final ERDiagram diagram = (ERDiagram) getRoot().getContents().getModel();
+        final int viewMode = diagram.getDiagramContents().getSettings().getOutlineViewMode();
 
         boolean first = true;
-        StringBuilder sb = new StringBuilder();
-
-        for (NormalColumn foreignKeyColumn : model.getForeignKeyColumns()) {
+        final StringBuilder sb = new StringBuilder();
+        for (final NormalColumn foreignKeyColumn : model.getForeignKeyColumns()) {
             if (first) {
                 first = false;
             } else {
@@ -55,10 +51,8 @@ public class RelationOutlineEditPart extends AbstractOutlineEditPart {
 
             if (viewMode == DiagramSettings.VIEW_MODE_PHYSICAL) {
                 sb.append(Format.null2blank(foreignKeyColumn.getPhysicalName()));
-
             } else if (viewMode == DiagramSettings.VIEW_MODE_LOGICAL) {
                 sb.append(Format.null2blank(foreignKeyColumn.getLogicalName()));
-
             } else {
                 sb.append(Format.null2blank(foreignKeyColumn.getLogicalName()));
                 sb.append("/");
@@ -66,27 +60,24 @@ public class RelationOutlineEditPart extends AbstractOutlineEditPart {
             }
         }
 
-        this.setWidgetText(sb.toString());
-        this.setWidgetImage(Activator.getImage(ImageKey.FOREIGN_KEY));
+        setWidgetText(sb.toString());
+        setWidgetImage(Activator.getImage(ImageKey.FOREIGN_KEY));
     }
 
     @Override
     protected void createEditPolicies() {
-        this.installEditPolicy(EditPolicy.CONNECTION_ROLE, new RelationEditPolicy());
+        installEditPolicy(EditPolicy.CONNECTION_ROLE, new RelationEditPolicy());
     }
 
     @Override
     public void performRequest(Request request) {
-        Relationship relation = (Relationship) this.getModel();
-
+        final Relationship relation = (Relationship) getModel();
         if (request.getType().equals(RequestConstants.REQ_OPEN)) {
-            Relationship copy = relation.copy();
-
-            RelationshipDialog dialog = new RelationshipDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), copy);
-
+            final Relationship copy = relation.copy();
+            final RelationshipDialog dialog = new RelationshipDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), copy);
             if (dialog.open() == IDialogConstants.OK_ID) {
-                ChangeRelationshipPropertyCommand command = new ChangeRelationshipPropertyCommand(relation, copy);
-                this.execute(command);
+                final ChangeRelationshipPropertyCommand command = new ChangeRelationshipPropertyCommand(relation, copy);
+                execute(command);
             }
         }
 

--- a/src/org/dbflute/erflute/editor/controller/editpart/outline/table/TableOutlineEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/outline/table/TableOutlineEditPart.java
@@ -30,7 +30,7 @@ import org.eclipse.ui.PlatformUI;
 
 public class TableOutlineEditPart extends AbstractOutlineEditPart implements DeleteableEditPart {
 
-    private boolean quickMode;
+    private final boolean quickMode;
 
     public TableOutlineEditPart(boolean quickMode) {
         this.quickMode = quickMode;
@@ -38,15 +38,12 @@ public class TableOutlineEditPart extends AbstractOutlineEditPart implements Del
 
     @Override
     protected List getModelChildren() {
-        List<AbstractModel> children = new ArrayList<AbstractModel>();
-
-        ERTable table = (ERTable) this.getModel();
-
-        Category category = this.getCurrentCategory();
-
+        final ERTable table = (ERTable) getModel();
+        final Category category = getCurrentCategory();
+        final List<AbstractModel> children = new ArrayList<>();
         if (!quickMode) {
-            for (Relationship relation : table.getIncomingRelationshipList()) {
-                if (category == null || category.contains(relation.getWalkerSource())) {
+            for (final Relationship relation : table.getIncomingRelationshipList()) {
+                if (category == null || category.contains(relation.getSourceWalker())) {
                     children.add(relation);
                 }
             }
@@ -60,46 +57,35 @@ public class TableOutlineEditPart extends AbstractOutlineEditPart implements Del
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(ERTable.PROPERTY_CHANGE_PHYSICAL_NAME)) {
             refreshName();
-
         } else if (evt.getPropertyName().equals(ERTable.PROPERTY_CHANGE_LOGICAL_NAME)) {
             refreshName();
-
         } else if (evt.getPropertyName().equals(ERTable.PROPERTY_CHANGE_COLUMNS)) {
             refresh();
-
         } else if (evt.getPropertyName().equals(IndexSet.PROPERTY_CHANGE_INDEXES)) {
             refresh();
-
         }
     }
 
     protected void refreshName() {
-        ERTable model = (ERTable) this.getModel();
-
-        ERDiagram diagram = (ERDiagram) this.getRoot().getContents().getModel();
-
+        final ERDiagram diagram = (ERDiagram) getRoot().getContents().getModel();
+        final int viewMode = diagram.getDiagramContents().getSettings().getOutlineViewMode();
+        final ERTable model = (ERTable) getModel();
         String name = null;
-
-        int viewMode = diagram.getDiagramContents().getSettings().getOutlineViewMode();
-
         if (viewMode == DiagramSettings.VIEW_MODE_PHYSICAL) {
             if (model.getPhysicalName() != null) {
                 name = model.getPhysicalName();
-
             } else {
                 name = "";
             }
         } else if (viewMode == DiagramSettings.VIEW_MODE_LOGICAL) {
             if (model.getLogicalName() != null) {
                 name = model.getLogicalName();
-
             } else {
                 name = "";
             }
         } else {
             if (model.getLogicalName() != null) {
                 name = model.getLogicalName();
-
             } else {
                 name = "";
             }
@@ -112,42 +98,41 @@ public class TableOutlineEditPart extends AbstractOutlineEditPart implements Del
             }
         }
 
-        this.setWidgetText(diagram.filter(name));
-        this.setWidgetImage(Activator.getImage(ImageKey.TABLE));
+        setWidgetText(diagram.filter(name));
+        setWidgetImage(Activator.getImage(ImageKey.TABLE));
     }
 
     @Override
     protected void refreshOutlineVisuals() {
-        this.refreshName();
+        refreshName();
 
-        for (Object child : this.getChildren()) {
-            EditPart part = (EditPart) child;
+        for (final Object child : getChildren()) {
+            final EditPart part = (EditPart) child;
             part.refresh();
         }
     }
 
     @Override
     protected void createEditPolicies() {
-        this.installEditPolicy(EditPolicy.COMPONENT_ROLE, new DiagramWalkerComponentEditPolicy());
+        installEditPolicy(EditPolicy.COMPONENT_ROLE, new DiagramWalkerComponentEditPolicy());
         // this.installEditPolicy(EditPolicy.SELECTION_FEEDBACK_ROLE, null);
     }
 
     @Override
     public void performRequest(Request request) {
-        ERTable table = (ERTable) this.getModel();
-        ERDiagram diagram = (ERDiagram) this.getRoot().getContents().getModel();
-
+        final ERTable table = (ERTable) getModel();
+        final ERDiagram diagram = (ERDiagram) getRoot().getContents().getModel();
         if (request.getType().equals(RequestConstants.REQ_OPEN)) {
-            ERTable copyTable = table.copyData();
+            final ERTable copyTable = table.copyData();
 
-            TableDialog dialog =
-                    new TableDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), this.getViewer(), copyTable, diagram
+            final TableDialog dialog =
+                    new TableDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), getViewer(), copyTable, diagram
                             .getDiagramContents().getColumnGroupSet());
 
             if (dialog.open() == IDialogConstants.OK_ID) {
-                CompoundCommand command = ERTableEditPart.createChangeTablePropertyCommand(diagram, table, copyTable);
+                final CompoundCommand command = ERTableEditPart.createChangeTablePropertyCommand(diagram, table, copyTable);
 
-                this.execute(command.unwrap());
+                execute(command.unwrap());
             }
         }
 
@@ -159,6 +144,7 @@ public class TableOutlineEditPart extends AbstractOutlineEditPart implements Del
         return new SelectEditPartTracker(this);
     }
 
+    @Override
     public boolean isDeleteable() {
         return true;
     }

--- a/src/org/dbflute/erflute/editor/controller/editpart/outline/vdiagram/ERVirtualDiagramOutlineEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/outline/vdiagram/ERVirtualDiagramOutlineEditPart.java
@@ -66,7 +66,7 @@ public class ERVirtualDiagramOutlineEditPart extends AbstractOutlineEditPart imp
         final ERDiagram diagram = this.getDiagram();
         if (request.getType().equals(RequestConstants.REQ_OPEN)) {
             final OpenERModelCommand command = new OpenERModelCommand(diagram, model);
-            // TODO 仮想ダイアグラムを開くだけで、編集中になる問題を修正するために"this.execute(command);"から下記コードに書き換えた。
+            // TODO ymd 仮想ダイアグラムを開くだけで、編集中になる問題を修正するために"this.execute(command);"から下記コードに書き換えた。
             // コマンドスタックに積んで実行すると、doExecuteで何もしなくてもファイル変更とみなされるらしい。
             // そもそも、オブジェクトの状態を変更しない(undoを実装できない)手続きは、コマンドで実装しない方が良いかもしれない。
             command.execute();

--- a/src/org/dbflute/erflute/editor/controller/editpart/outline/vdiagram/ERVirtualDiagramOutlineEditPart.java
+++ b/src/org/dbflute/erflute/editor/controller/editpart/outline/vdiagram/ERVirtualDiagramOutlineEditPart.java
@@ -66,7 +66,10 @@ public class ERVirtualDiagramOutlineEditPart extends AbstractOutlineEditPart imp
         final ERDiagram diagram = this.getDiagram();
         if (request.getType().equals(RequestConstants.REQ_OPEN)) {
             final OpenERModelCommand command = new OpenERModelCommand(diagram, model);
-            this.execute(command);
+            // TODO 仮想ダイアグラムを開くだけで、編集中になる問題を修正するために"this.execute(command);"から下記コードに書き換えた。
+            // コマンドスタックに積んで実行すると、doExecuteで何もしなくてもファイル変更とみなされるらしい。
+            // そもそも、オブジェクトの状態を変更しない(undoを実装できない)手続きは、コマンドで実装しない方が良いかもしれない。
+            command.execute();
         }
         super.performRequest(request);
     }

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/connection/ERDiagramBendpointEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/connection/ERDiagramBendpointEditPolicy.java
@@ -21,17 +21,17 @@ public class ERDiagramBendpointEditPolicy extends BendpointEditPolicy {
 
     @Override
     protected Command getCreateBendpointCommand(BendpointRequest bendpointrequest) {
-        AbstractConnectionEditPart connectionEditPart = (AbstractConnectionEditPart) this.getHost();
-        WalkerConnection connection = (WalkerConnection) connectionEditPart.getModel();
+        final AbstractConnectionEditPart connectionEditPart = (AbstractConnectionEditPart) getHost();
+        final WalkerConnection connection = (WalkerConnection) connectionEditPart.getModel();
 
-        if (connection.getWalkerSource() == connection.getWalkerTarget()) {
+        if (connection.getSourceWalker() == connection.getTargetWalker()) {
             return null;
         }
 
-        Point point = bendpointrequest.getLocation();
-        this.getConnection().translateToRelative(point);
+        final Point point = bendpointrequest.getLocation();
+        getConnection().translateToRelative(point);
 
-        CreateBendpointCommand createBendpointCommand =
+        final CreateBendpointCommand createBendpointCommand =
                 new CreateBendpointCommand(connection, point.x, point.y, bendpointrequest.getIndex());
 
         return createBendpointCommand;
@@ -39,43 +39,43 @@ public class ERDiagramBendpointEditPolicy extends BendpointEditPolicy {
 
     @Override
     protected Command getDeleteBendpointCommand(BendpointRequest bendpointrequest) {
-        WalkerConnection connection = (WalkerConnection) getHost().getModel();
+        final WalkerConnection connection = (WalkerConnection) getHost().getModel();
 
-        if (connection.getWalkerSource() == connection.getWalkerTarget()) {
+        if (connection.getSourceWalker() == connection.getTargetWalker()) {
             return null;
         }
 
-        DeleteBendpointCommand command = new DeleteBendpointCommand(connection, bendpointrequest.getIndex());
+        final DeleteBendpointCommand command = new DeleteBendpointCommand(connection, bendpointrequest.getIndex());
 
         return command;
     }
 
     @Override
     protected Command getMoveBendpointCommand(BendpointRequest bendpointrequest) {
-        ConnectionEditPart editPart = (ConnectionEditPart) this.getHost();
+        final ConnectionEditPart editPart = (ConnectionEditPart) getHost();
 
-        Point point = bendpointrequest.getLocation();
-        this.getConnection().translateToRelative(point);
+        final Point point = bendpointrequest.getLocation();
+        getConnection().translateToRelative(point);
 
-        MoveBendpointCommand command = new MoveBendpointCommand(editPart, point.x, point.y, bendpointrequest.getIndex());
+        final MoveBendpointCommand command = new MoveBendpointCommand(editPart, point.x, point.y, bendpointrequest.getIndex());
 
         return command;
     }
 
     @Override
     protected List createSelectionHandles() {
-        this.showSelectedLine();
+        showSelectedLine();
         return super.createSelectionHandles();
     }
 
     @Override
     protected void showSelection() {
-        EditPart contents = this.getHost().getRoot().getContents();
+        final EditPart contents = getHost().getRoot().getContents();
         if (contents instanceof ERVirtualDiagramEditPart) {
-            ERVirtualDiagramEditPart part = (ERVirtualDiagramEditPart) contents;
+            final ERVirtualDiagramEditPart part = (ERVirtualDiagramEditPart) contents;
             part.refreshVisuals();
         } else {
-            ERDiagramEditPart diagramEditPart = (ERDiagramEditPart) contents;
+            final ERDiagramEditPart diagramEditPart = (ERDiagramEditPart) contents;
             diagramEditPart.refreshVisuals();
         }
 
@@ -83,13 +83,13 @@ public class ERDiagramBendpointEditPolicy extends BendpointEditPolicy {
     }
 
     protected void showSelectedLine() {
-        ERDiagramConnection connection = (ERDiagramConnection) this.getHostFigure();
+        final ERDiagramConnection connection = (ERDiagramConnection) getHostFigure();
         connection.setSelected(true);
     }
 
     @Override
     protected void removeSelectionHandles() {
-        ERDiagramConnection connection = (ERDiagramConnection) this.getHostFigure();
+        final ERDiagramConnection connection = (ERDiagramConnection) getHostFigure();
         connection.setSelected(false);
 
         super.removeSelectionHandles();

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/connection/RelationBendpointEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/connection/RelationBendpointEditPolicy.java
@@ -30,7 +30,7 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
         final Relationship relation = (Relationship) getHost().getModel();
         final RelationEditPart editPart = (RelationEditPart) getHost();
 
-        if (relation.getWalkerSource() == relation.getWalkerTarget()) {
+        if (relation.getSourceWalker() == relation.getTargetWalker()) {
             if (bendpointrequest.getIndex() != 1) {
                 return;
             }
@@ -88,7 +88,7 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
     protected void showCreateBendpointFeedback(BendpointRequest bendpointrequest) {
         final Relationship relation = (Relationship) getHost().getModel();
 
-        if (relation.getWalkerSource() == relation.getWalkerTarget()) {
+        if (relation.getSourceWalker() == relation.getTargetWalker()) {
             return;
         }
         super.showCreateBendpointFeedback(bendpointrequest);
@@ -105,7 +105,7 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
         final Relationship relation = (Relationship) getHost().getModel();
         final RelationEditPart editPart = (RelationEditPart) getHost();
 
-        if (relation.getWalkerSource() == relation.getWalkerTarget()) {
+        if (relation.getSourceWalker() == relation.getTargetWalker()) {
             if (bendpointrequest.getIndex() != 1) {
                 return null;
 
@@ -160,7 +160,7 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
     @Override
     protected List createSelectionHandles() {
         final Relationship relation = (Relationship) getHost().getModel();
-        if (relation.getWalkerSource() == relation.getWalkerTarget()) {
+        if (relation.getSourceWalker() == relation.getTargetWalker()) {
             showSelectedLine();
 
             if (getHost().getRoot().getContents() instanceof ERDiagramEditPart) {

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/connection/RelationBendpointEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/connection/RelationBendpointEditPolicy.java
@@ -27,25 +27,25 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
 
     @Override
     protected void showMoveBendpointFeedback(BendpointRequest bendpointrequest) {
-        Relationship relation = (Relationship) getHost().getModel();
-        RelationEditPart editPart = (RelationEditPart) this.getHost();
+        final Relationship relation = (Relationship) getHost().getModel();
+        final RelationEditPart editPart = (RelationEditPart) getHost();
 
         if (relation.getWalkerSource() == relation.getWalkerTarget()) {
             if (bendpointrequest.getIndex() != 1) {
                 return;
             }
-            Point point = bendpointrequest.getLocation();
-            this.getConnection().translateToRelative(point);
-            Bendpoint rate = this.getRate(point);
+            final Point point = bendpointrequest.getLocation();
+            getConnection().translateToRelative(point);
+            final Bendpoint rate = getRate(point);
             rate.setRelative(true);
 
-            float rateX = (100f - (rate.getX() / 2)) / 100;
-            float rateY = (100f - (rate.getY() / 2)) / 100;
+            final float rateX = (100f - (rate.getX() / 2)) / 100;
+            final float rateY = (100f - (rate.getY() / 2)) / 100;
 
-            ERTableEditPart tableEditPart = (ERTableEditPart) editPart.getSource();
-            Rectangle bounds = tableEditPart.getFigure().getBounds();
+            final ERTableEditPart tableEditPart = (ERTableEditPart) editPart.getSource();
+            final Rectangle bounds = tableEditPart.getFigure().getBounds();
 
-            Rectangle rect = new Rectangle();
+            final Rectangle rect = new Rectangle();
             rect.x = (int) (bounds.x + (bounds.width * rateX));
             rect.y = (int) (bounds.y + (bounds.height * rateY));
             rect.width = (int) (bounds.width * rate.getX() / 100);
@@ -55,18 +55,18 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
 
             relation.setTargetLocationp((int) (100 * rateX), 100);
 
-            LayerManager manager = (LayerManager) tableEditPart.getRoot();
-            IFigure layer = manager.getLayer(LayerConstants.PRIMARY_LAYER);
-            this.getFeedbackLayer().setBounds(layer.getBounds());
+            final LayerManager manager = (LayerManager) tableEditPart.getRoot();
+            final IFigure layer = manager.getLayer(LayerConstants.PRIMARY_LAYER);
+            getFeedbackLayer().setBounds(layer.getBounds());
 
-            List children = this.getFeedbackLayer().getChildren();
+            final List children = getFeedbackLayer().getChildren();
             children.clear();
-            this.getFeedbackLayer().repaint();
+            getFeedbackLayer().repaint();
 
-            ZoomManager zoomManager = ((ScalableFreeformRootEditPart) this.getHost().getRoot()).getZoomManager();
-            double zoom = zoomManager.getZoom();
+            final ZoomManager zoomManager = ((ScalableFreeformRootEditPart) getHost().getRoot()).getZoomManager();
+            final double zoom = zoomManager.getZoom();
 
-            Polyline feedbackFigure = new Polyline();
+            final Polyline feedbackFigure = new Polyline();
             feedbackFigure.addPoint(new Point((int) (rect.x * zoom), (int) (rect.y * zoom)));
             feedbackFigure.addPoint(new Point((int) (rect.x * zoom), (int) ((rect.y + rect.height) * zoom)));
             feedbackFigure.addPoint(new Point((int) ((rect.x + rect.width) * zoom), (int) ((rect.y + rect.height) * zoom)));
@@ -77,7 +77,7 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
 
             feedbackFigure.translateToRelative(feedbackFigure.getLocation());
 
-            this.addFeedback(feedbackFigure);
+            addFeedback(feedbackFigure);
 
         } else {
             super.showMoveBendpointFeedback(bendpointrequest);
@@ -86,7 +86,7 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
 
     @Override
     protected void showCreateBendpointFeedback(BendpointRequest bendpointrequest) {
-        Relationship relation = (Relationship) getHost().getModel();
+        final Relationship relation = (Relationship) getHost().getModel();
 
         if (relation.getWalkerSource() == relation.getWalkerTarget()) {
             return;
@@ -96,46 +96,47 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
 
     @Override
     protected void eraseConnectionFeedback(BendpointRequest request) {
-        this.getFeedbackLayer().getChildren().clear();
+        getFeedbackLayer().getChildren().clear();
         super.eraseConnectionFeedback(request);
     }
 
     @Override
     protected Command getMoveBendpointCommand(BendpointRequest bendpointrequest) {
-        Relationship relation = (Relationship) getHost().getModel();
-        RelationEditPart editPart = (RelationEditPart) this.getHost();
+        final Relationship relation = (Relationship) getHost().getModel();
+        final RelationEditPart editPart = (RelationEditPart) getHost();
 
         if (relation.getWalkerSource() == relation.getWalkerTarget()) {
             if (bendpointrequest.getIndex() != 1) {
                 return null;
 
             } else {
-                Point point = bendpointrequest.getLocation();
-                Bendpoint rate = this.getRate(point);
+                final Point point = bendpointrequest.getLocation();
+                final Bendpoint rate = getRate(point);
 
-                MoveRelationBendpointCommand command =
+                final MoveRelationBendpointCommand command =
                         new MoveRelationBendpointCommand(editPart, rate.getX(), rate.getY(), bendpointrequest.getIndex());
 
                 return command;
             }
         }
 
-        Point point = bendpointrequest.getLocation();
-        this.getConnection().translateToRelative(point);
+        final Point point = bendpointrequest.getLocation();
+        getConnection().translateToRelative(point);
 
-        MoveRelationBendpointCommand command = new MoveRelationBendpointCommand(editPart, point.x, point.y, bendpointrequest.getIndex());
+        final MoveRelationBendpointCommand command =
+                new MoveRelationBendpointCommand(editPart, point.x, point.y, bendpointrequest.getIndex());
 
         return command;
     }
 
     private Bendpoint getRate(Point point) {
-        RelationEditPart editPart = (RelationEditPart) this.getHost();
+        final RelationEditPart editPart = (RelationEditPart) getHost();
 
-        ERTableEditPart tableEditPart = (ERTableEditPart) editPart.getSource();
-        Rectangle rectangle = tableEditPart.getFigure().getBounds();
+        final ERTableEditPart tableEditPart = (ERTableEditPart) editPart.getSource();
+        final Rectangle rectangle = tableEditPart.getFigure().getBounds();
 
-        int xRate = (point.x - rectangle.x - rectangle.width) * 200 / rectangle.width;
-        int yRate = (point.y - rectangle.y - rectangle.height) * 200 / rectangle.height;
+        final int xRate = (point.x - rectangle.x - rectangle.width) * 200 / rectangle.width;
+        final int yRate = (point.y - rectangle.y - rectangle.height) * 200 / rectangle.height;
 
         return new Bendpoint(xRate, yRate);
     }
@@ -144,7 +145,7 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
     protected void showSelection() {
         super.showSelection();
 
-        RelationEditPart editPart = (RelationEditPart) this.getHost();
+        final RelationEditPart editPart = (RelationEditPart) getHost();
         editPart.refresh();
     }
 
@@ -152,26 +153,24 @@ public class RelationBendpointEditPolicy extends ERDiagramBendpointEditPolicy {
     protected void hideSelection() {
         super.hideSelection();
 
-        RelationEditPart editPart = (RelationEditPart) this.getHost();
+        final RelationEditPart editPart = (RelationEditPart) getHost();
         editPart.refresh();
     }
 
     @Override
     protected List createSelectionHandles() {
-        Relationship relation = (Relationship) getHost().getModel();
-
+        final Relationship relation = (Relationship) getHost().getModel();
         if (relation.getWalkerSource() == relation.getWalkerTarget()) {
-            List<BendpointMoveHandle> list = new ArrayList<BendpointMoveHandle>();
+            showSelectedLine();
 
-            ConnectionEditPart connEP = (ConnectionEditPart) getHost();
+            if (getHost().getRoot().getContents() instanceof ERDiagramEditPart) {
+                // TODO ymd ここを通るケースを確認できず。消すかもしれない。
+                final ERDiagramEditPart diagramEditPart = (ERDiagramEditPart) getHost().getRoot().getContents();
+                diagramEditPart.refreshVisuals();
+            }
 
-            list.add(new BendpointMoveHandle(connEP, 1, 2));
-
-            this.showSelectedLine();
-
-            ERDiagramEditPart diagramEditPart = (ERDiagramEditPart) this.getHost().getRoot().getContents();
-            diagramEditPart.refreshVisuals();
-
+            final List<BendpointMoveHandle> list = new ArrayList<>();
+            list.add(new BendpointMoveHandle((ConnectionEditPart) getHost(), 1, 2));
             return list;
         }
 

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerComponentEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerComponentEditPolicy.java
@@ -79,7 +79,7 @@ public class DiagramWalkerComponentEditPolicy extends ComponentEditPolicy {
                 }
 
                 for (final WalkerConnection connection : walker.getOutgoings()) {
-                    final DiagramWalker target = connection.getWalkerTarget();
+                    final DiagramWalker target = connection.getTargetWalker();
                     if (!targets.contains(target)) {
                         if (connection instanceof Relationship) {
                             command.add(new DeleteRelationshipCommand((Relationship) connection, true));

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerComponentEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerComponentEditPolicy.java
@@ -29,15 +29,16 @@ public class DiagramWalkerComponentEditPolicy extends ComponentEditPolicy {
     @Override
     protected Command createDeleteCommand(GroupRequest request) {
         try {
-            if (this.getHost() instanceof DeleteableEditPart) {
-                final DeleteableEditPart editPart = (DeleteableEditPart) this.getHost();
+            if (getHost() instanceof DeleteableEditPart) {
+                final DeleteableEditPart editPart = (DeleteableEditPart) getHost();
                 if (!editPart.isDeleteable()) {
                     return null;
                 }
             } else {
                 return null;
             }
-            final Set<DiagramWalker> targets = new HashSet<DiagramWalker>();
+
+            final Set<DiagramWalker> targets = new HashSet<>();
             for (final Object object : request.getEditParts()) {
                 final EditPart editPart = (EditPart) object;
                 final Object model = editPart.getModel();
@@ -46,8 +47,8 @@ public class DiagramWalkerComponentEditPolicy extends ComponentEditPolicy {
                 }
             }
 
-            final ERDiagram diagram = ERModelUtil.getDiagram(this.getHost().getRoot().getContents());
-            DiagramWalker walker = (DiagramWalker) this.getHost().getModel();
+            final ERDiagram diagram = ERModelUtil.getDiagram(getHost().getRoot().getContents());
+            DiagramWalker walker = (DiagramWalker) getHost().getModel();
 
             if (walker instanceof Category) {
                 return new DeleteCategoryCommand(diagram, (Category) walker);
@@ -58,14 +59,16 @@ public class DiagramWalkerComponentEditPolicy extends ComponentEditPolicy {
                 virtualTable = (ERVirtualTable) walker;
                 walker = ((ERVirtualTable) walker).getRawTable();
             }
+
             if (!diagram.getDiagramContents().getDiagramWalkers().contains(walker) && !(walker instanceof Category)
                     && !(walker instanceof WalkerNote) && !(walker instanceof WalkerGroup)) {
                 return null;
             }
 
             final CompoundCommand command = new CompoundCommand();
-
             if (virtualTable == null) {
+                command.add(new DeleteElementCommand(diagram, walker));
+
                 for (final WalkerConnection connection : walker.getIncomings()) {
                     if (connection instanceof Relationship) {
                         command.add(new DeleteRelationshipCommand((Relationship) connection, true));
@@ -76,9 +79,7 @@ public class DiagramWalkerComponentEditPolicy extends ComponentEditPolicy {
                 }
 
                 for (final WalkerConnection connection : walker.getOutgoings()) {
-
                     final DiagramWalker target = connection.getWalkerTarget();
-
                     if (!targets.contains(target)) {
                         if (connection instanceof Relationship) {
                             command.add(new DeleteRelationshipCommand((Relationship) connection, true));
@@ -87,15 +88,14 @@ public class DiagramWalkerComponentEditPolicy extends ComponentEditPolicy {
                         }
                     }
                 }
-
-                command.add(new DeleteElementCommand(diagram, walker));
             } else {
                 command.add(new DeleteElementCommand(diagram, virtualTable));
             }
+
             return command.unwrap();
         } catch (final Exception e) {
             Activator.showExceptionDialog(e);
+            return null;
         }
-        return null;
     }
 }

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
@@ -121,11 +121,11 @@ public class DiagramWalkerGraphicalNodeEditPolicy extends GraphicalNodeEditPolic
             return null;
         }
         final Relationship relation = (Relationship) connection;
-        if (relation.getWalkerSource() == relation.getWalkerTarget()) {
+        if (relation.getSourceWalker() == relation.getTargetWalker()) {
             return null;
         }
         final DiagramWalker newSource = ((DiagramWalker) reconnectrequest.getTarget().getModel()).toMaterialize();
-        if (!relation.getWalkerSource().equals(newSource)) {
+        if (!relation.getSourceWalker().equals(newSource)) {
             return null;
         }
         final DiagramWalkerEditPart sourceEditPart = (DiagramWalkerEditPart) reconnectrequest.getConnectionEditPart().getSource();
@@ -153,11 +153,11 @@ public class DiagramWalkerGraphicalNodeEditPolicy extends GraphicalNodeEditPolic
             return null;
         }
         final Relationship relation = (Relationship) connection;
-        if (relation.getWalkerSource() == relation.getWalkerTarget()) {
+        if (relation.getSourceWalker() == relation.getTargetWalker()) {
             return null;
         }
         final DiagramWalker newTarget = ((DiagramWalker) reconnectrequest.getTarget().getModel()).toMaterialize();
-        if (!relation.getWalkerTarget().equals(newTarget)) {
+        if (!relation.getTargetWalker().equals(newTarget)) {
             return null;
         }
         final DiagramWalkerEditPart targetEditPart = (DiagramWalkerEditPart) reconnectrequest.getConnectionEditPart().getTarget();

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
@@ -156,7 +156,7 @@ public class DiagramWalkerGraphicalNodeEditPolicy extends GraphicalNodeEditPolic
         if (relation.getWalkerSource() == relation.getWalkerTarget()) {
             return null;
         }
-        final DiagramWalker newTarget = (DiagramWalker) reconnectrequest.getTarget().getModel();
+        final DiagramWalker newTarget = ((DiagramWalker) reconnectrequest.getTarget().getModel()).toMaterialize();
         if (!relation.getWalkerTarget().equals(newTarget)) {
             return null;
         }

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
@@ -59,7 +59,7 @@ public class DiagramWalkerGraphicalNodeEditPolicy extends GraphicalNodeEditPolic
         final EditPart editPart = request.getTargetEditPart();
         final Object object = request.getNewObject();
         if (editPart instanceof ERTableEditPart) {
-            final Command command = this.getRelationCreateCommand(request, object);
+            final Command command = getRelationCreateCommand(request, object);
             if (command != null) {
                 return command;
             }

--- a/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
+++ b/src/org/dbflute/erflute/editor/controller/editpolicy/element/node/DiagramWalkerGraphicalNodeEditPolicy.java
@@ -124,7 +124,7 @@ public class DiagramWalkerGraphicalNodeEditPolicy extends GraphicalNodeEditPolic
         if (relation.getWalkerSource() == relation.getWalkerTarget()) {
             return null;
         }
-        final DiagramWalker newSource = (DiagramWalker) reconnectrequest.getTarget().getModel();
+        final DiagramWalker newSource = ((DiagramWalker) reconnectrequest.getTarget().getModel()).toMaterialize();
         if (!relation.getWalkerSource().equals(newSource)) {
             return null;
         }

--- a/src/org/dbflute/erflute/editor/model/ERDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/ERDiagram.java
@@ -112,7 +112,7 @@ public class ERDiagram extends ViewableModel {
 
         // 仮想ダイアグラムへのノート追加でない場合
         if (!(getCurrentVirtualDiagram() != null && walker instanceof WalkerNote)) {
-            diagramContents.getDiagramWalkers().addDiagramWalker(walker);
+            diagramContents.getDiagramWalkers().add(walker);
         }
 
         if (editor != null) {
@@ -131,26 +131,26 @@ public class ERDiagram extends ViewableModel {
         firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
-    public void removeContent(DiagramWalker element) {
+    public void removeWalker(DiagramWalker walker) {
         if (getCurrentVirtualDiagram() != null) {
-            getCurrentVirtualDiagram().removeContent(element);
-        } else {
-            diagramContents.getDiagramWalkers().remove(element);
-            if (element instanceof ERTable) {
-                // メインビューのテーブルを削除したときは、仮想ビューのノードも削除（線が消えずに残ってしまう）
-                for (final ERVirtualDiagram model : getDiagramContents().getVirtualDiagramSet()) {
-                    final ERVirtualTable vtable = model.findVirtualTable((TableView) element);
-                    model.removeContent(vtable);
-                }
+            getCurrentVirtualDiagram().removeWalker(walker);
+        }
+
+        diagramContents.getDiagramWalkers().remove(walker);
+        if (walker instanceof ERTable) {
+            // メインビューのテーブルを削除したときは、仮想ビューのノードも削除（線が消えずに残ってしまう）
+            for (final ERVirtualDiagram vdiagram : getDiagramContents().getVirtualDiagramSet()) {
+                final ERVirtualTable vtable = vdiagram.findVirtualTable((TableView) walker);
+                vdiagram.removeWalker(vtable);
             }
         }
 
-        if (element instanceof TableView) {
-            diagramContents.getDictionary().remove((TableView) element);
+        if (walker instanceof TableView) {
+            diagramContents.getDictionary().remove((TableView) walker);
         }
 
         for (final Category category : diagramContents.getSettings().getCategorySetting().getAllCategories()) {
-            category.getContents().remove(element);
+            category.getContents().remove(walker);
         }
 
         firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
@@ -159,6 +159,14 @@ public class ERDiagram extends ViewableModel {
     public void replaceContents(DiagramContents newDiagramContents) {
         this.diagramContents = newDiagramContents;
         firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
+    }
+
+    public boolean virtualDiagramContains(DiagramWalker walker) {
+        if (getCurrentVirtualDiagram() == null) {
+            return false;
+        }
+
+        return getCurrentCategory().contains(walker);
     }
 
     // ===================================================================================

--- a/src/org/dbflute/erflute/editor/model/ERDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/ERDiagram.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.graphics.Color;
 /**
  * @author modified by jflute (originated in ermaster)
  *
- * TODO 現状2つの債務を持っている。
+ * TODO ymd 現状2つの債務を持っている。
  * 1.メインダイアグラムのモデル
  * 2.メインダイアグラムと仮想ダイアグラムのコントローラ
  *
@@ -324,7 +324,7 @@ public class ERDiagram extends ViewableModel {
     }
 
     /*
-     * TODO なるべく使わない方向で。直接触らないでERDiagramを介する。
+     * TODO ymd なるべく使わない方向で。直接触らないでERDiagramを介する。
      * クライアントクラスは、getDiagram().getCurrentVirtualDiagram().目的の操作()ではなく、
      * getDiagram().目的の操作()を実行する。
      */

--- a/src/org/dbflute/erflute/editor/model/ERDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/ERDiagram.java
@@ -340,11 +340,13 @@ public class ERDiagram extends ViewableModel {
         return currentVirtualDiagram;
     }
 
-    public void setCurrentVirtualDiagram(ERVirtualDiagram vdiagram, String defaultModelName) {
+    public void setCurrentVirtualDiagram(ERVirtualDiagram vdiagram) {
         this.currentVirtualDiagram = vdiagram;
-        this.defaultModelName = defaultModelName;
         if (vdiagram != null) {
+            this.defaultModelName = vdiagram.getName();
             vdiagram.changeAll();
+        } else {
+            this.defaultModelName = null;
         }
     }
 
@@ -426,5 +428,9 @@ public class ERDiagram extends ViewableModel {
 
     public void setMousePoint(Point mousePoint) {
         this.mousePoint = mousePoint;
+    }
+
+    public boolean isVirtual() {
+        return getCurrentVirtualDiagram() != null;
     }
 }

--- a/src/org/dbflute/erflute/editor/model/ERDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/ERDiagram.java
@@ -62,7 +62,7 @@ public class ERDiagram extends ViewableModel {
     private int y;
     private DBSettings dbSettings;
     private PageSettings pageSetting;
-    public Point mousePoint = new Point();
+    private Point mousePoint = new Point();
     private String defaultModelName;
 
     // ===================================================================================
@@ -418,5 +418,13 @@ public class ERDiagram extends ViewableModel {
 
     public String getDefaultModelName() {
         return defaultModelName;
+    }
+
+    public Point getMousePoint() {
+        return mousePoint;
+    }
+
+    public void setMousePoint(Point mousePoint) {
+        this.mousePoint = mousePoint;
     }
 }

--- a/src/org/dbflute/erflute/editor/model/ERDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/ERDiagram.java
@@ -8,10 +8,8 @@ import org.dbflute.erflute.editor.ERFluteMultiPageEditor;
 import org.dbflute.erflute.editor.model.diagram_contents.DiagramContents;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalkerSet;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.Location;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.category.Category;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.WalkerGroup;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.note.WalkerNote;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERVirtualTable;
@@ -26,6 +24,12 @@ import org.eclipse.swt.graphics.Color;
 
 /**
  * @author modified by jflute (originated in ermaster)
+ *
+ * TODO 現状2つの債務を持っている。
+ * 1.メインダイアグラムのモデル
+ * 2.メインダイアグラムと仮想ダイアグラムのコントローラ
+ *
+ * この2つの債務を分離したい。ERDiagramにはコントローラの債務だけ残す。
  */
 public class ERDiagram extends ViewableModel {
 
@@ -68,8 +72,8 @@ public class ERDiagram extends ViewableModel {
         this.diagramContents = new DiagramContents();
         this.diagramContents.getSettings().setDatabase(database);
         this.pageSetting = new PageSettings();
-        this.setDefaultColor(DesignResources.ERDIAGRAM_DEFAULT_COLOR);
-        this.setColor(DesignResources.WHITE);
+        setDefaultColor(DesignResources.ERDIAGRAM_DEFAULT_COLOR);
+        setColor(DesignResources.WHITE);
     }
 
     // ===================================================================================
@@ -86,80 +90,75 @@ public class ERDiagram extends ViewableModel {
     //                                                                    ================
     public void addNewWalker(DiagramWalker walker) {
         Activator.debug(this, "addNewWalker()", "...Adding new walker: " + walker);
+
         if (walker instanceof WalkerNote) {
             walker.setColor(DesignResources.NOTE_DEFAULT_COLOR);
         } else {
             walker.setColor(DesignResources.ERDIAGRAM_DEFAULT_COLOR);
         }
+
         walker.setFontName(getFontName());
         walker.setFontSize(getFontSize());
+
         addWalkerPlainly(walker);
     }
 
-    public void addWalkerPlainly(DiagramWalker diagramWalker) {
-        DiagramWalker walker = diagramWalker;
-        if (getCurrentVirtualDiagram() != null && walker instanceof ERTable) {
-            ERVirtualTable virtualTable;
-            if (walker instanceof ERVirtualTable) {
-                virtualTable = (ERVirtualTable) walker;
-                walker = virtualTable.getRawTable();
-            } else {
-                virtualTable = new ERVirtualTable(getCurrentVirtualDiagram(), (ERTable) walker);
-                virtualTable.setLocation(new Location(walker.getX(), walker.getY(), walker.getWidth(), walker.getHeight()));
-            }
-
-            // 仮想ダイアグラム上に仮想テーブルを追加する
-            getCurrentVirtualDiagram().addTable(virtualTable);
-
-            // メインダイアグラム上では左上に配置
-            walker.setLocation(new Location(0, 0, walker.getWidth(), walker.getHeight()));
+    public void addWalkerPlainly(final DiagramWalker walker) {
+        if (getCurrentVirtualDiagram() != null) {
+            getCurrentVirtualDiagram().addWalkerPlainly(walker);
         }
+
         walker.setDiagram(this);
-        diagramContents.getDiagramWalkers().addDiagramWalker(walker);
+
+        // 仮想ダイアグラムへのノート追加でない場合
+        if (!(getCurrentVirtualDiagram() != null && walker instanceof WalkerNote)) {
+            diagramContents.getDiagramWalkers().addDiagramWalker(walker);
+        }
+
         if (editor != null) {
             final Category category = editor.getCurrentPageCategory();
             if (category != null) {
                 category.getContents().add(walker);
             }
         }
+
         if (walker instanceof TableView) {
             for (final NormalColumn normalColumn : ((TableView) walker).getNormalColumns()) {
                 getDiagramContents().getDictionary().add(normalColumn);
             }
         }
+
         firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     public void removeContent(DiagramWalker element) {
-        if (element instanceof ERVirtualTable) {
-            // メインビューのノードは残して仮想テーブルだけ削除
-            currentVirtualDiagram.remove((ERVirtualTable) element);
-        } else if (element instanceof WalkerGroup && currentVirtualDiagram != null) {
-            currentVirtualDiagram.remove((WalkerGroup) element);
-        } else if (element instanceof WalkerNote && currentVirtualDiagram != null) {
-            currentVirtualDiagram.remove((WalkerNote) element);
+        if (getCurrentVirtualDiagram() != null) {
+            getCurrentVirtualDiagram().removeContent(element);
         } else {
-            this.diagramContents.getDiagramWalkers().remove(element);
+            diagramContents.getDiagramWalkers().remove(element);
             if (element instanceof ERTable) {
-                // メインビューのテーブルを削除したときは、ビューのノードも削除（線が消えずに残ってしまう）
+                // メインビューのテーブルを削除したときは、仮想ビューのノードも削除（線が消えずに残ってしまう）
                 for (final ERVirtualDiagram model : getDiagramContents().getVirtualDiagramSet()) {
                     final ERVirtualTable vtable = model.findVirtualTable((TableView) element);
-                    model.remove(vtable);
+                    model.removeContent(vtable);
                 }
             }
         }
+
         if (element instanceof TableView) {
-            this.diagramContents.getDictionary().remove((TableView) element);
+            diagramContents.getDictionary().remove((TableView) element);
         }
-        for (final Category category : this.diagramContents.getSettings().getCategorySetting().getAllCategories()) {
+
+        for (final Category category : diagramContents.getSettings().getCategorySetting().getAllCategories()) {
             category.getContents().remove(element);
         }
+
         firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     public void replaceContents(DiagramContents newDiagramContents) {
         this.diagramContents = newDiagramContents;
-        this.firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
+        firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     // ===================================================================================
@@ -176,7 +175,7 @@ public class ERDiagram extends ViewableModel {
     }
 
     public void changeTable(TableView tableView) {
-        this.firePropertyChange(PROPERTY_CHANGE_TABLE, null, tableView);
+        firePropertyChange(PROPERTY_CHANGE_TABLE, null, tableView);
     }
 
     /**
@@ -209,98 +208,68 @@ public class ERDiagram extends ViewableModel {
     //                                                                   =================
     public void setDatabase(String str) {
         final String oldDatabase = getDatabase();
-        this.getDiagramContents().getSettings().setDatabase(str);
+        getDiagramContents().getSettings().setDatabase(str);
         if (str != null && !str.equals(oldDatabase)) {
-            this.firePropertyChange(PROPERTY_CHANGE_DATABASE, oldDatabase, getDatabase());
-            this.changeAll();
+            firePropertyChange(PROPERTY_CHANGE_DATABASE, oldDatabase, getDatabase());
+            changeAll();
         }
     }
 
     public String getDatabase() {
-        return this.getDiagramContents().getSettings().getDatabase();
+        return getDiagramContents().getSettings().getDatabase();
     }
 
     public void restoreDatabase(String str) {
-        this.getDiagramContents().getSettings().setDatabase(str);
+        getDiagramContents().getSettings().setDatabase(str);
     }
 
     // ===================================================================================
     //                                                                   Category Handling
     //                                                                   =================
     public void setCurrentCategoryPageName() {
-        this.editor.setCurrentCategoryPageName();
+        editor.setCurrentCategoryPageName();
     }
 
     public void addCategory(Category category) {
-        category.setColor(this.defaultColor[0], this.defaultColor[1], this.defaultColor[2]);
-        this.getDiagramContents().getSettings().getCategorySetting().addCategoryAsSelected(category);
-        this.editor.initVirtualPages();
-        this.firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
+        category.setColor(defaultColor[0], defaultColor[1], defaultColor[2]);
+        getDiagramContents().getSettings().getCategorySetting().addCategoryAsSelected(category);
+        editor.initVirtualPages();
+        firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     public void removeCategory(Category category) {
-        this.getDiagramContents().getSettings().getCategorySetting().removeCategory(category);
-        this.editor.initVirtualPages();
-        this.firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
+        getDiagramContents().getSettings().getCategorySetting().removeCategory(category);
+        editor.initVirtualPages();
+        firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     public void restoreCategories() {
-        this.editor.initVirtualPages();
-        this.firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
+        editor.initVirtualPages();
+        firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     // ===================================================================================
     //                                                                    Various Handling
     //                                                                    ================
     public void change() {
-        this.firePropertyChange(PROPERTY_CHANGE_SETTINGS, null, null);
+        firePropertyChange(PROPERTY_CHANGE_SETTINGS, null, null);
     }
 
     public void changeAll() {
-        this.firePropertyChange(PROPERTY_CHANGE_ALL, null, null);
+        firePropertyChange(PROPERTY_CHANGE_ALL, null, null);
     }
 
     public void changeAll(List<DiagramWalker> nodeElementList) {
-        this.firePropertyChange(PROPERTY_CHANGE_ALL, null, nodeElementList);
+        firePropertyChange(PROPERTY_CHANGE_ALL, null, nodeElementList);
     }
 
     public void setSettings(DiagramSettings settings) {
-        this.getDiagramContents().setSettings(settings);
-        this.editor.initVirtualPages();
+        getDiagramContents().setSettings(settings);
+        editor.initVirtualPages();
 
-        this.firePropertyChange(PROPERTY_CHANGE_SETTINGS, null, null);
-        this.firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
+        firePropertyChange(PROPERTY_CHANGE_SETTINGS, null, null);
+        firePropertyChange(DiagramWalkerSet.PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
-
-    //	/**
-    //	 * 全体ビューもしくは通常ビューで更新された内容を、全てのビューに展開します。
-    //	 * @param event 発生したイベント
-    //	 * @param nodeElement 更新したモデル
-    //	 */
-    //	public void refreshAllModel(PropertyChangeEvent event, NodeElement nodeElement) {
-    //		if (nodeElement instanceof ERVirtualTable) {
-    //			ERTable table = ((ERVirtualTable)nodeElement).getRawTable();
-    //			table.getDiagram().doChangeTable(table);
-    //			for (ERModel model : getDiagramContents().getModelSet()) {
-    //				ERVirtualTable vtable = model.findVirtualTable(table);
-    //				if (vtable != null) {
-    //					vtable.doChangeTable();
-    ////					vtable.firePropertyChange(event.getPropertyName(), event.getOldValue(), event.getNewValue());
-    //				}
-    //			}
-    //		} else if (nodeElement instanceof ERTable) {
-    //			ERTable table = (ERTable)nodeElement;
-    //			table.getDiagram().doChangeTable(table);
-    //			for (ERModel model : getDiagramContents().getModelSet()) {
-    //				ERVirtualTable vtable = model.findVirtualTable(table);
-    //				if (vtable != null) {
-    //					vtable.doChangeTable();
-    ////					vtable.firePropertyChange(event.getPropertyName(), event.getOldValue(), event.getNewValue());
-    //				}
-    //			}
-    //		}
-    //
-    //	}
 
     // ===================================================================================
     //                                                                      Basic Override
@@ -354,6 +323,11 @@ public class ERDiagram extends ViewableModel {
         this.tooltip = tooltip;
     }
 
+    /*
+     * TODO なるべく使わない方向で。直接触らないでERDiagramを介する。
+     * クライアントクラスは、getDiagram().getCurrentVirtualDiagram().目的の操作()ではなく、
+     * getDiagram().目的の操作()を実行する。
+     */
     public ERVirtualDiagram getCurrentVirtualDiagram() {
         return currentVirtualDiagram;
     }
@@ -411,7 +385,7 @@ public class ERDiagram extends ViewableModel {
         if (str == null) {
             return str;
         }
-        final DiagramSettings settings = this.getDiagramContents().getSettings();
+        final DiagramSettings settings = getDiagramContents().getSettings();
         if (settings.isCapital()) {
             return str.toUpperCase();
         }

--- a/src/org/dbflute/erflute/editor/model/ERModelUtil.java
+++ b/src/org/dbflute/erflute/editor/model/ERModelUtil.java
@@ -2,6 +2,8 @@ package org.dbflute.erflute.editor.model;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.List;
 
 import org.dbflute.erflute.Activator;
 import org.dbflute.erflute.editor.VirtualDiagramEditor;
@@ -34,6 +36,26 @@ public class ERModelUtil {
         return (ERDiagram) model;
     }
 
+    public static boolean refreshDiagram(ERDiagram diagram, DiagramWalker... elements) {
+        return refreshDiagram(diagram, Arrays.asList(elements));
+    }
+
+    public static boolean refreshDiagram(ERDiagram diagram, List<DiagramWalker> elements) {
+        if (refreshDiagram(diagram)) {
+            elements.stream().forEach(element -> {
+                if (element instanceof ERTable) {
+                    final IEditorPart activeEditor = diagram.getEditor().getActiveEditor();
+                    if (activeEditor instanceof VirtualDiagramEditor) {
+                        final VirtualDiagramEditor editor = (VirtualDiagramEditor) activeEditor;
+                        editor.reveal((ERTable) element);
+                    }
+                }
+            });
+            return true;
+        }
+        return false;
+    }
+
     public static boolean refreshDiagram(ERDiagram diagram) {
         if (diagram == null) {
             return false;
@@ -48,20 +70,6 @@ public class ERModelUtil {
             diagram.changeAll();
             return true;
         }
-    }
-
-    public static boolean refreshDiagram(ERDiagram diagram, DiagramWalker element) {
-        if (refreshDiagram(diagram)) {
-            if (element instanceof ERTable) {
-                final IEditorPart activeEditor = diagram.getEditor().getActiveEditor();
-                if (activeEditor instanceof VirtualDiagramEditor) {
-                    final VirtualDiagramEditor editor = (VirtualDiagramEditor) activeEditor;
-                    editor.reveal((ERTable) element);
-                }
-            }
-            return true;
-        }
-        return false;
     }
 
     public static void openDirectory(IResource resource) {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
@@ -85,18 +85,18 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
             int i = 0;
             if (isReferenceForPK()) {
                 for (final NormalColumn sourceColumn : ((ERTable) sourceTable).getPrimaryKeys()) {
-                    final NormalColumn foreignKeyColumn = createForeiKeyColumn(sourceColumn, foreignKeyColumnList, i++);
+                    final NormalColumn foreignKeyColumn = createForeignKeyColumn(sourceColumn, foreignKeyColumnList, i++);
                     target.addColumn(foreignKeyColumn);
                 }
             } else if (referredCompoundUniqueKey != null) {
                 for (final NormalColumn sourceColumn : referredCompoundUniqueKey.getColumnList()) {
-                    final NormalColumn foreignKeyColumn = createForeiKeyColumn(sourceColumn, foreignKeyColumnList, i++);
+                    final NormalColumn foreignKeyColumn = createForeignKeyColumn(sourceColumn, foreignKeyColumnList, i++);
                     target.addColumn(foreignKeyColumn);
                 }
             } else {
                 for (final NormalColumn sourceColumn : sourceTable.getNormalColumns()) {
                     if (sourceColumn == referredSimpleUniqueColumn) {
-                        final NormalColumn foreignKeyColumn = createForeiKeyColumn(sourceColumn, foreignKeyColumnList, i++);
+                        final NormalColumn foreignKeyColumn = createForeignKeyColumn(sourceColumn, foreignKeyColumnList, i++);
                         target.addColumn(foreignKeyColumn);
                         break;
                     }
@@ -105,7 +105,7 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
         }
     }
 
-    private NormalColumn createForeiKeyColumn(NormalColumn referencedColumn, List<NormalColumn> foreignKeyColumnList, int index) {
+    private NormalColumn createForeignKeyColumn(NormalColumn referencedColumn, List<NormalColumn> foreignKeyColumnList, int index) {
         final NormalColumn foreignKeyColumn = new NormalColumn(referencedColumn, referencedColumn, this, false);
         if (foreignKeyColumnList != null) {
             final NormalColumn data = foreignKeyColumnList.get(index);

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
@@ -72,30 +72,30 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     }
 
     public void setTargetTableView(TableView target) {
-        this.setTargetTableView(target, null);
+        setTargetTableView(target, null);
     }
 
     public void setTargetTableView(TableView target, List<NormalColumn> foreignKeyColumnList) {
-        if (this.getTargetTableView() != null) {
+        if (getTargetTableView() != null) {
             removeAllForeignKey();
         }
         super.setTargetWalker(target);
         if (target != null) {
             final TableView sourceTable = (TableView) getWalkerSource();
             int i = 0;
-            if (this.isReferenceForPK()) {
+            if (isReferenceForPK()) {
                 for (final NormalColumn sourceColumn : ((ERTable) sourceTable).getPrimaryKeys()) {
                     final NormalColumn foreignKeyColumn = createForeiKeyColumn(sourceColumn, foreignKeyColumnList, i++);
                     target.addColumn(foreignKeyColumn);
                 }
-            } else if (this.referredCompoundUniqueKey != null) {
+            } else if (referredCompoundUniqueKey != null) {
                 for (final NormalColumn sourceColumn : referredCompoundUniqueKey.getColumnList()) {
                     final NormalColumn foreignKeyColumn = createForeiKeyColumn(sourceColumn, foreignKeyColumnList, i++);
                     target.addColumn(foreignKeyColumn);
                 }
             } else {
                 for (final NormalColumn sourceColumn : sourceTable.getNormalColumns()) {
-                    if (sourceColumn == this.referredSimpleUniqueColumn) {
+                    if (sourceColumn == referredSimpleUniqueColumn) {
                         final NormalColumn foreignKeyColumn = createForeiKeyColumn(sourceColumn, foreignKeyColumnList, i++);
                         target.addColumn(foreignKeyColumn);
                         break;
@@ -103,7 +103,6 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
                 }
             }
         }
-        firePropertyChange("target", null, target);
     }
 
     private NormalColumn createForeiKeyColumn(NormalColumn referencedColumn, List<NormalColumn> foreignKeyColumnList, int index) {
@@ -125,13 +124,12 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     public void setTargetTableWithExistingColumns(ERTable target, List<NormalColumn> referencedColumnList,
             List<NormalColumn> foreignKeyColumnList) {
         super.setTargetWalker(target);
-        this.firePropertyChange("target", null, target);
     }
 
     public List<NormalColumn> getForeignKeyColumns() {
-        final List<NormalColumn> columnList = new ArrayList<NormalColumn>();
+        final List<NormalColumn> columnList = new ArrayList<>();
         if (getTargetTableView() != null) {
-            for (final NormalColumn column : this.getTargetTableView().getNormalColumns()) {
+            for (final NormalColumn column : getTargetTableView().getNormalColumns()) {
                 if (column.isForeignKey()) {
                     final NormalColumn foreignKeyColumn = column;
                     for (final Relationship relation : foreignKeyColumn.getRelationshipList()) {
@@ -151,11 +149,11 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     //                                                                              ======
     public void delete(boolean removeForeignKey, Dictionary dictionary) {
         super.delete();
-        for (final NormalColumn foreignKeyColumn : this.getForeignKeyColumns()) {
+        for (final NormalColumn foreignKeyColumn : getForeignKeyColumns()) {
             foreignKeyColumn.removeReference(this);
             if (removeForeignKey) {
                 if (foreignKeyColumn.getRelationshipList().isEmpty()) {
-                    this.getTargetTableView().removeColumn(foreignKeyColumn);
+                    getTargetTableView().removeColumn(foreignKeyColumn);
                 }
             } else {
                 dictionary.add(foreignKeyColumn);
@@ -165,32 +163,32 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
 
     public Relationship copy() {
         final Relationship to =
-                new Relationship(this.isReferenceForPK(), this.getReferredCompoundUniqueKey(), this.getReferredSimpleUniqueColumn());
+                new Relationship(isReferenceForPK(), getReferredCompoundUniqueKey(), getReferredSimpleUniqueColumn());
 
-        to.setForeignKeyName(this.getForeignKeyName());
-        to.setOnDeleteAction(this.getOnDeleteAction());
-        to.setOnUpdateAction(this.getOnUpdateAction());
-        to.setChildCardinality(this.getChildCardinality());
-        to.setParentCardinality(this.getParentCardinality());
+        to.setForeignKeyName(getForeignKeyName());
+        to.setOnDeleteAction(getOnDeleteAction());
+        to.setOnUpdateAction(getOnUpdateAction());
+        to.setChildCardinality(getChildCardinality());
+        to.setParentCardinality(getParentCardinality());
 
-        to.sourceWalker = this.getSourceTableView();
-        to.targetWalker = this.getTargetTableView();
+        to.sourceWalker = getSourceTableView();
+        to.targetWalker = getTargetTableView();
 
         return to;
     }
 
     public Relationship restructureRelationData(Relationship to) {
-        to.setForeignKeyName(this.getForeignKeyName());
-        to.setOnDeleteAction(this.getOnDeleteAction());
-        to.setOnUpdateAction(this.getOnUpdateAction());
-        to.setChildCardinality(this.getChildCardinality());
-        to.setParentCardinality(this.getParentCardinality());
+        to.setForeignKeyName(getForeignKeyName());
+        to.setOnDeleteAction(getOnDeleteAction());
+        to.setOnUpdateAction(getOnUpdateAction());
+        to.setChildCardinality(getChildCardinality());
+        to.setParentCardinality(getParentCardinality());
 
         return to;
     }
 
     public boolean isReferenceForPK() {
-        return this.referenceForPK;
+        return referenceForPK;
     }
 
     public void setReferenceForPK(boolean referenceForPK) {
@@ -201,36 +199,36 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
         if (referredSimpleUniqueColumn == sourceColumn) {
             return;
         }
-        this.removeAllForeignKey();
+        removeAllForeignKey();
         final NormalColumn foreignKeyColumn = new NormalColumn(sourceColumn, sourceColumn, this, false);
         getTargetTableView().addColumn(foreignKeyColumn);
-        referenceForPK = false;
-        referredSimpleUniqueColumn = sourceColumn;
-        referredCompoundUniqueKey = null;
+        this.referenceForPK = false;
+        this.referredSimpleUniqueColumn = sourceColumn;
+        this.referredCompoundUniqueKey = null;
     }
 
     public void setForeignKeyForComplexUniqueKey(CompoundUniqueKey compoundUniqueKey) {
         if (referredCompoundUniqueKey == compoundUniqueKey) {
             return;
         }
-        this.removeAllForeignKey();
+        removeAllForeignKey();
         for (final NormalColumn sourceColumn : compoundUniqueKey.getColumnList()) {
             final NormalColumn foreignKeyColumn = new NormalColumn(sourceColumn, sourceColumn, this, false);
             getTargetTableView().addColumn(foreignKeyColumn);
         }
-        referenceForPK = false;
-        referredSimpleUniqueColumn = null;
-        referredCompoundUniqueKey = compoundUniqueKey;
+        this.referenceForPK = false;
+        this.referredSimpleUniqueColumn = null;
+        this.referredCompoundUniqueKey = compoundUniqueKey;
     }
 
     public void setForeignKeyColumnForPK() {
-        if (this.referenceForPK) {
+        if (referenceForPK) {
             return;
         }
-        this.removeAllForeignKey();
-        for (final NormalColumn sourceColumn : ((ERTable) this.getSourceTableView()).getPrimaryKeys()) {
+        removeAllForeignKey();
+        for (final NormalColumn sourceColumn : ((ERTable) getSourceTableView()).getPrimaryKeys()) {
             final NormalColumn foreignKeyColumn = new NormalColumn(sourceColumn, sourceColumn, this, false);
-            this.getTargetTableView().addColumn(foreignKeyColumn);
+            getTargetTableView().addColumn(foreignKeyColumn);
         }
         this.referenceForPK = true;
         this.referredSimpleUniqueColumn = null;
@@ -249,13 +247,13 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
                 }
             }
         }
-        this.getTargetTableView().setDirty();
+        getTargetTableView().setDirty();
     }
 
     public String buildRelationshipId() { // for complete state e.g. when writing
         final TableView targetTable = getTargetTableView();
         final List<NormalColumn> foreignKeyColumns = getForeignKeyColumns();
-        final List<String> physicalColumnNameList = new ArrayList<String>();
+        final List<String> physicalColumnNameList = new ArrayList<>();
         for (final NormalColumn column : foreignKeyColumns) {
             physicalColumnNameList.add(column.getPhysicalName());
         }
@@ -294,7 +292,7 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
 
     @Override
     public int compareTo(Relationship otherRelation) {
-        return this.getTargetTableView().compareTo(otherRelation.getTargetTableView());
+        return getTargetTableView().compareTo(otherRelation.getTargetTableView());
     }
 
     @Override
@@ -330,7 +328,7 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     }
 
     public String getChildCardinality() {
-        return this.childCardinality;
+        return childCardinality;
     }
 
     public void setChildCardinality(String childCardinality) {
@@ -352,7 +350,7 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     }
 
     public CompoundUniqueKey getReferredCompoundUniqueKey() {
-        return this.referredCompoundUniqueKey;
+        return referredCompoundUniqueKey;
     }
 
     public void setReferredSimpleUniqueColumn(NormalColumn referredSimpleUniqueColumn) {
@@ -360,7 +358,7 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     }
 
     public NormalColumn getReferredSimpleUniqueColumn() {
-        return this.referredSimpleUniqueColumn;
+        return referredSimpleUniqueColumn;
     }
 
     public int getSourceXp() {
@@ -390,7 +388,7 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     }
 
     public boolean isReferedStrictly() {
-        for (final NormalColumn column : this.getForeignKeyColumns()) {
+        for (final NormalColumn column : getForeignKeyColumns()) {
             if (column.isReferedStrictly()) {
                 return true;
             }
@@ -400,6 +398,6 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     }
 
     public DiagramSettings getDiagramSettings() {
-        return this.getSourceTableView().getDiagram().getDiagramContents().getSettings();
+        return getSourceTableView().getDiagram().getDiagramContents().getSettings();
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/Relationship.java
@@ -64,11 +64,11 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
     //                                                                           TableView
     //                                                                           =========
     public TableView getSourceTableView() {
-        return (TableView) getWalkerSource();
+        return (TableView) getSourceWalker();
     }
 
     public TableView getTargetTableView() {
-        return (TableView) getWalkerTarget();
+        return (TableView) getTargetWalker();
     }
 
     public void setTargetTableView(TableView target) {
@@ -81,7 +81,7 @@ public class Relationship extends WalkerConnection implements Comparable<Relatio
         }
         super.setTargetWalker(target);
         if (target != null) {
-            final TableView sourceTable = (TableView) getWalkerSource();
+            final TableView sourceTable = (TableView) getSourceWalker();
             int i = 0;
             if (isReferenceForPK()) {
                 for (final NormalColumn sourceColumn : ((ERTable) sourceTable).getPrimaryKeys()) {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
@@ -21,16 +21,13 @@ public abstract class WalkerConnection extends AbstractModel {
     protected DiagramWalker sourceWalker; // e.g. MEMBER_STATUS, note
     protected DiagramWalker targetWalker; // e.g. MEMBER, noted table
     private List<Bendpoint> bendPoints = new ArrayList<>();
-    private boolean deleted = false;
 
     public void delete() {
-        this.deleted = true;
         sourceWalker.removeOutgoing(this);
         targetWalker.removeIncoming(this);
     }
 
     public void connect() {
-        this.deleted = false;
         if (sourceWalker != null) {
             sourceWalker.addOutgoing(this);
         }
@@ -127,9 +124,5 @@ public abstract class WalkerConnection extends AbstractModel {
 
     public List<Bendpoint> getBendpoints() {
         return bendPoints;
-    }
-
-    public boolean isDeleted() {
-        return deleted;
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
@@ -24,16 +24,12 @@ public abstract class WalkerConnection extends AbstractModel {
 
     public void delete() {
         sourceWalker.removeOutgoing(this);
-        targetWalker.removeIncoming(this);
+        ownerWalker.removeIncoming(this);
     }
 
-    public void connect() {
-        if (sourceWalker != null) {
-            sourceWalker.addOutgoing(this);
-        }
-        if (targetWalker != null) {
-            targetWalker.addIncoming(this);
-        }
+    public void connect(DiagramWalker sourceWalker, DiagramWalker targetWalker) {
+        setSourceWalker(sourceWalker);
+        setTargetWalker(targetWalker);
     }
 
     public void addBendpoint(int index, Bendpoint point) {
@@ -92,7 +88,7 @@ public abstract class WalkerConnection extends AbstractModel {
         this.ownerWalker = ownerWalker;
     }
 
-    public DiagramWalker getWalkerSource() {
+    public DiagramWalker getSourceWalker() {
         return sourceWalker;
     }
 
@@ -104,10 +100,10 @@ public abstract class WalkerConnection extends AbstractModel {
         if (sourceWalker != null) {
             sourceWalker.addOutgoing(this);
         }
-        firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, sourceWalker);
+        firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, null);
     }
 
-    public DiagramWalker getWalkerTarget() {
+    public DiagramWalker getTargetWalker() {
         return targetWalker;
     }
 
@@ -119,10 +115,15 @@ public abstract class WalkerConnection extends AbstractModel {
         if (targetWalker != null) {
             targetWalker.addIncoming(this);
         }
-        firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, targetWalker);
+        firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, null);
     }
 
     public List<Bendpoint> getBendpoints() {
         return bendPoints;
+    }
+
+    public boolean isDeleted() {
+        return sourceWalker == null || targetWalker == null
+                || !sourceWalker.haveConnection(this) || !targetWalker.haveConnection(this);
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
@@ -30,6 +30,7 @@ public abstract class WalkerConnection extends AbstractModel {
     }
 
     public void connect() {
+        this.deleted = false;
         if (sourceWalker != null) {
             sourceWalker.addOutgoing(this);
         }
@@ -99,12 +100,12 @@ public abstract class WalkerConnection extends AbstractModel {
     }
 
     public void setSourceWalker(DiagramWalker sourceWalker) {
-        if (this.sourceWalker != null) {
-            this.sourceWalker.removeOutgoing(this);
+        if (sourceWalker != null) {
+            sourceWalker.removeOutgoing(this);
         }
         this.sourceWalker = sourceWalker;
-        if (this.sourceWalker != null) {
-            this.sourceWalker.addOutgoing(this);
+        if (sourceWalker != null) {
+            sourceWalker.addOutgoing(this);
         }
         firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, sourceWalker);
     }
@@ -114,12 +115,12 @@ public abstract class WalkerConnection extends AbstractModel {
     }
 
     public void setTargetWalker(DiagramWalker targetWalker) {
-        if (this.targetWalker != null) {
-            this.targetWalker.removeIncoming(this);
+        if (targetWalker != null) {
+            targetWalker.removeIncoming(this);
         }
         this.targetWalker = targetWalker;
-        if (this.targetWalker != null) {
-            this.targetWalker.addIncoming(this);
+        if (targetWalker != null) {
+            targetWalker.addIncoming(this);
         }
         firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, targetWalker);
     }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/connection/WalkerConnection.java
@@ -20,9 +20,11 @@ public abstract class WalkerConnection extends AbstractModel {
     protected DiagramWalker ownerWalker; // e.g. ERTable, WalkerNote
     protected DiagramWalker sourceWalker; // e.g. MEMBER_STATUS, note
     protected DiagramWalker targetWalker; // e.g. MEMBER, noted table
-    private List<Bendpoint> bendPoints = new ArrayList<Bendpoint>();
+    private List<Bendpoint> bendPoints = new ArrayList<>();
+    private boolean deleted = false;
 
     public void delete() {
+        this.deleted = true;
         sourceWalker.removeOutgoing(this);
         targetWalker.removeIncoming(this);
     }
@@ -73,7 +75,7 @@ public abstract class WalkerConnection extends AbstractModel {
     @Override
     public WalkerConnection clone() {
         final WalkerConnection clone = (WalkerConnection) super.clone();
-        final List<Bendpoint> cloneBendPoints = new ArrayList<Bendpoint>();
+        final List<Bendpoint> cloneBendPoints = new ArrayList<>();
         for (final Bendpoint bendPoint : bendPoints) {
             cloneBendPoints.add((Bendpoint) bendPoint.clone());
         }
@@ -119,10 +121,14 @@ public abstract class WalkerConnection extends AbstractModel {
         if (this.targetWalker != null) {
             this.targetWalker.addIncoming(this);
         }
-        firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, sourceWalker);
+        firePropertyChange(PROPERTY_CHANGE_CONNECTION, null, targetWalker);
     }
 
     public List<Bendpoint> getBendpoints() {
         return bendPoints;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalker.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalker.java
@@ -12,7 +12,7 @@ import org.dbflute.erflute.editor.model.diagram_contents.element.connection.Walk
 /**
  * @author modified by jflute (originated in ermaster)
  */
-public abstract class DiagramWalker extends ViewableModel implements ObjectModel {
+public abstract class DiagramWalker extends ViewableModel implements ObjectModel, Materializable<DiagramWalker> {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalker.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalker.java
@@ -22,8 +22,8 @@ public abstract class DiagramWalker extends ViewableModel implements ObjectModel
 
     protected ERDiagram diagram; // null allowed: when virtual model element
     protected Location location;
-    protected List<WalkerConnection> incomings = new ArrayList<WalkerConnection>(); // target
-    protected List<WalkerConnection> outgoings = new ArrayList<WalkerConnection>(); // source
+    protected List<WalkerConnection> incomings = new ArrayList<>(); // target
+    protected List<WalkerConnection> outgoings = new ArrayList<>(); // source
 
     public abstract boolean needsUpdateOtherModel();
 
@@ -32,8 +32,8 @@ public abstract class DiagramWalker extends ViewableModel implements ObjectModel
     }
 
     public List<DiagramWalker> getReferringElementList() {
-        final List<DiagramWalker> referringElementList = new ArrayList<DiagramWalker>();
-        for (final WalkerConnection connectionElement : this.getOutgoings()) {
+        final List<DiagramWalker> referringElementList = new ArrayList<>();
+        for (final WalkerConnection connectionElement : getOutgoings()) {
             final DiagramWalker targetElement = connectionElement.getWalkerTarget();
             referringElementList.add(targetElement);
         }
@@ -41,8 +41,8 @@ public abstract class DiagramWalker extends ViewableModel implements ObjectModel
     }
 
     public List<DiagramWalker> getReferedElementList() {
-        final List<DiagramWalker> referedElementList = new ArrayList<DiagramWalker>();
-        for (final WalkerConnection connectionElement : this.getIncomings()) {
+        final List<DiagramWalker> referedElementList = new ArrayList<>();
+        for (final WalkerConnection connectionElement : getIncomings()) {
             final DiagramWalker sourceElement = connectionElement.getWalkerSource();
             referedElementList.add(sourceElement);
         }
@@ -52,7 +52,7 @@ public abstract class DiagramWalker extends ViewableModel implements ObjectModel
     @Override
     public DiagramWalker clone() {
         final DiagramWalker clone = (DiagramWalker) super.clone();
-        clone.location = this.location.clone();
+        clone.location = location.clone();
         clone.setIncoming(new ArrayList<WalkerConnection>());
         clone.setOutgoing(new ArrayList<WalkerConnection>());
         return clone;
@@ -87,17 +87,25 @@ public abstract class DiagramWalker extends ViewableModel implements ObjectModel
         return location.width;
     }
 
+    public void setWidth(final int width) {
+        location.width = width;
+    }
+
     public int getHeight() {
         return location.height;
     }
 
+    public void setHeight(final int height) {
+        location.height = height;
+    }
+
     public void setLocation(Location location) {
         this.location = location;
-        this.firePropertyChange(PROPERTY_CHANGE_RECTANGLE, null, null);
+        firePropertyChange(PROPERTY_CHANGE_RECTANGLE, null, null);
     }
 
     public List<WalkerConnection> getPersistentConnections() {
-        final List<WalkerConnection> filteredList = new ArrayList<WalkerConnection>();
+        final List<WalkerConnection> filteredList = new ArrayList<>();
         for (final WalkerConnection conn : incomings) {
             if (conn instanceof CommentConnection) {
                 continue;
@@ -113,17 +121,17 @@ public abstract class DiagramWalker extends ViewableModel implements ObjectModel
 
     public void setIncoming(List<WalkerConnection> relations) { // target
         this.incomings = relations;
-        this.firePropertyChange(PROPERTY_CHANGE_INCOMING, null, null);
+        firePropertyChange(PROPERTY_CHANGE_INCOMING, null, null);
     }
 
     public void addIncoming(WalkerConnection relation) { // called by e.g. setTarget()
-        this.incomings.add(relation);
-        this.firePropertyChange(PROPERTY_CHANGE_INCOMING, null, null);
+        incomings.add(relation);
+        firePropertyChange(PROPERTY_CHANGE_INCOMING, null, null);
     }
 
     public void removeIncoming(WalkerConnection relation) {
-        this.incomings.remove(relation);
-        this.firePropertyChange(PROPERTY_CHANGE_INCOMING, null, null);
+        incomings.remove(relation);
+        firePropertyChange(PROPERTY_CHANGE_INCOMING, null, null);
     }
 
     public List<WalkerConnection> getOutgoings() { // source
@@ -132,16 +140,16 @@ public abstract class DiagramWalker extends ViewableModel implements ObjectModel
 
     public void setOutgoing(List<WalkerConnection> relations) { // source
         this.outgoings = relations;
-        this.firePropertyChange(PROPERTY_CHANGE_OUTGOING, null, null);
+        firePropertyChange(PROPERTY_CHANGE_OUTGOING, null, null);
     }
 
     public void addOutgoing(WalkerConnection relation) { // called by e.g. setSource()
-        this.outgoings.add(relation);
-        this.firePropertyChange(PROPERTY_CHANGE_OUTGOING, null, null);
+        outgoings.add(relation);
+        firePropertyChange(PROPERTY_CHANGE_OUTGOING, null, null);
     }
 
     public void removeOutgoing(WalkerConnection relation) {
-        this.outgoings.remove(relation);
-        this.firePropertyChange(PROPERTY_CHANGE_OUTGOING, null, null);
+        outgoings.remove(relation);
+        firePropertyChange(PROPERTY_CHANGE_OUTGOING, null, null);
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalkerSet.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalkerSet.java
@@ -58,20 +58,20 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
     //                                                                            Add Node
     //                                                                            ========
     public void addDiagramWalker(DiagramWalker walker) {
-        if (contains(walker)) {
+        if (contains(walker.toMaterialize())) {
             return;
         }
 
         if (walker instanceof ERTable) {
-            this.tableSet.add((ERTable) walker);
+            tableSet.add((ERTable) walker);
         } else if (walker instanceof ERView) {
-            this.viewSet.add((ERView) walker);
+            viewSet.add((ERView) walker);
         } else if (walker instanceof WalkerNote) {
-            this.walkerNoteSet.add((WalkerNote) walker);
+            walkerNoteSet.add((WalkerNote) walker);
         } else if (walker instanceof WalkerGroup) {
-            this.walkerGroupSet.add((WalkerGroup) walker);
+            walkerGroupSet.add((WalkerGroup) walker);
         } else if (walker instanceof InsertedImage) {
-            this.insertedImageSet.add((InsertedImage) walker);
+            insertedImageSet.add((InsertedImage) walker);
         } else {
             System.out.println("*Unsupported diagram walker: " + walker);
         }
@@ -89,15 +89,15 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
 
     public void remove(DiagramWalker element) {
         if (element instanceof ERTable) {
-            this.tableSet.remove((ERTable) element);
+            tableSet.remove((ERTable) element);
         } else if (element instanceof ERView) {
-            this.viewSet.remove((ERView) element);
+            viewSet.remove((ERView) element);
         } else if (element instanceof WalkerGroup) {
-            this.walkerGroupSet.remove((WalkerGroup) element);
+            walkerGroupSet.remove((WalkerGroup) element);
         } else if (element instanceof WalkerNote) {
-            this.walkerNoteSet.remove((WalkerNote) element);
+            walkerNoteSet.remove((WalkerNote) element);
         } else if (element instanceof InsertedImage) {
-            this.insertedImageSet.remove((InsertedImage) element);
+            insertedImageSet.remove((InsertedImage) element);
         } else {
             System.out.println("*Unsupported diagram walker: " + element);
         }
@@ -106,16 +106,16 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
     }
 
     public boolean contains(DiagramWalker nodeElement) {
-        return this.walkerList.contains(nodeElement);
+        return walkerList.contains(nodeElement);
     }
 
     public void clear() {
-        this.tableSet.getList().clear();
-        this.viewSet.getList().clear();
-        this.walkerGroupSet.getList().clear();
-        this.walkerNoteSet.getList().clear();
-        this.insertedImageSet.getList().clear();
-        this.walkerList.clear();
+        tableSet.getList().clear();
+        viewSet.getList().clear();
+        walkerGroupSet.getList().clear();
+        walkerNoteSet.getList().clear();
+        insertedImageSet.getList().clear();
+        walkerList.clear();
     }
 
     public boolean isEmpty() {
@@ -128,8 +128,8 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
 
     public List<TableView> getTableViewList() {
         final List<TableView> nodeElementList = new ArrayList<>();
-        nodeElementList.addAll(this.tableSet.getList());
-        nodeElementList.addAll(this.viewSet.getList());
+        nodeElementList.addAll(tableSet.getList());
+        nodeElementList.addAll(viewSet.getList());
         return nodeElementList;
     }
 
@@ -165,7 +165,7 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
 
     @Override
     public Iterator<DiagramWalker> iterator() { // not sorted so cannot use for persistent
-        return this.getDiagramWalkerList().iterator();
+        return getDiagramWalkerList().iterator();
     }
 
     // ===================================================================================

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalkerSet.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalkerSet.java
@@ -57,25 +57,29 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
     // ===================================================================================
     //                                                                            Add Node
     //                                                                            ========
-    public void addDiagramWalker(DiagramWalker walker) {
+    public void add(DiagramWalker walker) {
         if (contains(walker.toMaterialize())) {
             return;
         }
 
         if (walker instanceof ERTable) {
             tableSet.add((ERTable) walker);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else if (walker instanceof ERView) {
             viewSet.add((ERView) walker);
-        } else if (walker instanceof WalkerNote) {
-            walkerNoteSet.add((WalkerNote) walker);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else if (walker instanceof WalkerGroup) {
             walkerGroupSet.add((WalkerGroup) walker);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
+        } else if (walker instanceof WalkerNote) {
+            walkerNoteSet.add((WalkerNote) walker);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else if (walker instanceof InsertedImage) {
             insertedImageSet.add((InsertedImage) walker);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else {
             System.out.println("*Unsupported diagram walker: " + walker);
         }
-
         if (walker instanceof WalkerGroup) {
             // エディタ上で、テーブルグループをテーブルの背面に配置するため。
             // テーブルの後にテーブルグループを追加すると、テーブルグループの後ろにテーブルが隠れてしまう。
@@ -83,26 +87,28 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
         } else {
             walkerList.add(walker);
         }
-
-        firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     public void remove(DiagramWalker element) {
         if (element instanceof ERTable) {
             tableSet.remove((ERTable) element);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else if (element instanceof ERView) {
             viewSet.remove((ERView) element);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else if (element instanceof WalkerGroup) {
             walkerGroupSet.remove((WalkerGroup) element);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else if (element instanceof WalkerNote) {
             walkerNoteSet.remove((WalkerNote) element);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else if (element instanceof InsertedImage) {
             insertedImageSet.remove((InsertedImage) element);
+            firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
         } else {
             System.out.println("*Unsupported diagram walker: " + element);
         }
         walkerList.remove(element);
-        firePropertyChange(PROPERTY_CHANGE_DIAGRAM_WALKER, null, null);
     }
 
     public boolean contains(DiagramWalker nodeElement) {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalkerSet.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/DiagramWalkerSet.java
@@ -58,6 +58,10 @@ public class DiagramWalkerSet extends AbstractModel implements Iterable<DiagramW
     //                                                                            Add Node
     //                                                                            ========
     public void addDiagramWalker(DiagramWalker walker) {
+        if (contains(walker)) {
+            return;
+        }
+
         if (walker instanceof ERTable) {
             this.tableSet.add((ERTable) walker);
         } else if (walker instanceof ERView) {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/Materializable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/Materializable.java
@@ -1,0 +1,19 @@
+package org.dbflute.erflute.editor.model.diagram_contents.element.node;
+
+/**
+ * TODO 非常に大きな変更につながるため、レビューした方が良いと思う。
+ * このインターフェースを実装するクラスは、サブクラスが何か(実体か、仮想か)について知っている必要がある。
+ * これは設計ミスではないか？代替策があれば、それに変える。
+ * @author ymd
+ * @param <TEntity> 仮想概念が参照する実体の型。
+ */
+public interface Materializable<TEntity> {
+    /**
+     * ERVirtualTabel等の仮想概念用拡張ポイント。
+     * @return 自身が実体なら自身を返す。仮想概念ならその実体を返す。
+     */
+    @SuppressWarnings("unchecked")
+    default TEntity toMaterialize() {
+        return (TEntity) this;
+    }
+}

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/Materializable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/Materializable.java
@@ -1,7 +1,7 @@
 package org.dbflute.erflute.editor.model.diagram_contents.element.node;
 
 /**
- * TODO 非常に大きな変更につながるため、レビューした方が良いと思う。
+ * TODO ymd 非常に大きな変更につながるため、レビューした方が良いと思う。
  * このインターフェースを実装するクラスは、サブクラスが何か(実体か、仮想か)について知っている必要がある。
  * これは設計ミスではないか？代替策があれば、それに変える。
  * @author ymd

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/ermodel/ERVirtualDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/ermodel/ERVirtualDiagram.java
@@ -1,6 +1,7 @@
 package org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -24,7 +25,7 @@ public class ERVirtualDiagram extends DiagramWalker {
 
     private static final long serialVersionUID = 1L;
     public static final String PROPERTY_CHANGE_VTABLES = "vtables";
-    public static final String REMOVE_VCONTENT = "remove_vcontent";
+    public static final String REMOVE_VWALKER = "remove_vwalker";
 
     private int[] defaultColor;
     private String name;
@@ -44,6 +45,10 @@ public class ERVirtualDiagram extends DiagramWalker {
     @Override
     public String getObjectType() {
         return "virtual_diagram";
+    }
+
+    public boolean contains(Object... models) {
+        return Arrays.stream(models).allMatch(m -> contains(m));
     }
 
     public boolean contains(Object model) {
@@ -157,13 +162,13 @@ public class ERVirtualDiagram extends DiagramWalker {
 
         if (walker instanceof WalkerNote) {
             notes.remove(walker);
-            firePropertyChange(REMOVE_VCONTENT, null, null);
+            firePropertyChange(REMOVE_VWALKER, null, null);
         } else if (walker instanceof WalkerGroup) {
             groups.remove(walker);
-            firePropertyChange(REMOVE_VCONTENT, null, null);
+            firePropertyChange(REMOVE_VWALKER, null, null);
         } else if (walker instanceof ERVirtualTable) {
             tables.remove(walker);
-            firePropertyChange(REMOVE_VCONTENT, null, null);
+            firePropertyChange(REMOVE_VWALKER, null, null);
         }
     }
 

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/ermodel/ERVirtualDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/ermodel/ERVirtualDiagram.java
@@ -45,6 +45,21 @@ public class ERVirtualDiagram extends DiagramWalker {
         return "virtual_diagram";
     }
 
+    public boolean contains(Object model) {
+        final List<DiagramWalker> walkers = new ArrayList<>(tables);
+        walkers.addAll(notes);
+        walkers.addAll(groups);
+        return walkers.stream().anyMatch(w -> w.toMaterialize().equals(convertToMaterializedIfCan(model)));
+    }
+
+    private static Object convertToMaterializedIfCan(Object model) {
+        if (model instanceof DiagramWalker) {
+            return ((DiagramWalker) model).toMaterialize();
+        } else {
+            return model;
+        }
+    }
+
     public boolean containsTable(ERTable table) {
         for (final ERVirtualTable vtable : tables) {
             if (vtable.getRawTable().equals(table)) {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/ermodel/ERVirtualDiagram.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/ermodel/ERVirtualDiagram.java
@@ -86,12 +86,13 @@ public class ERVirtualDiagram extends DiagramWalker {
     }
 
     public ERVirtualTable findVirtualTable(TableView table) {
+        ERVirtualTable ret = null;
         for (final ERVirtualTable vtable : tables) {
-            if (vtable.getRawTable().getPhysicalName().equals(table.getPhysicalName())) {
-                return vtable;
+            if (vtable.getRawTable().equals(table)) {
+                ret = vtable;
             }
         }
-        return null;
+        return ret;
     }
 
     public void deleteRelationship(Relationship relation) {
@@ -121,40 +122,49 @@ public class ERVirtualDiagram extends DiagramWalker {
     }
 
     public void addWalkerPlainly(DiagramWalker walker) {
+        if (walker == null) {
+            return;
+        }
+
         if (walker instanceof WalkerNote) {
             final WalkerNote note = (WalkerNote) walker;
             notes.add(note);
             note.setVirtualDiagram(this);
+            firePropertyChange(PROPERTY_CHANGE_VTABLES, null, null);
         } else if (walker instanceof WalkerGroup) {
             final WalkerGroup group = (WalkerGroup) walker;
             groups.add(group);
             group.setVirtualDiagram(this);
+            firePropertyChange(PROPERTY_CHANGE_VTABLES, null, null);
         } else if (walker instanceof ERTable) {
             ERVirtualTable virtualTable;
             if (walker instanceof ERVirtualTable) {
                 virtualTable = (ERVirtualTable) walker;
-                walker = virtualTable.getRawTable();
             } else {
                 virtualTable = new ERVirtualTable(this, (ERTable) walker);
                 virtualTable.setLocation(new Location(walker.getX(), walker.getY(), walker.getWidth(), walker.getHeight()));
                 walker.setLocation(new Location(0, 0, walker.getWidth(), walker.getHeight())); // メインダイアグラム上では左上に配置
             }
             tables.add(virtualTable);
+            firePropertyChange(PROPERTY_CHANGE_VTABLES, null, null);
         }
-
-        firePropertyChange(PROPERTY_CHANGE_VTABLES, null, null);
     }
 
-    public void removeContent(DiagramWalker walker) {
-        if (walker instanceof WalkerNote) {
-            notes.remove(walker);
-        } else if (walker instanceof WalkerGroup) {
-            groups.remove(walker);
-        } else if (walker instanceof ERVirtualTable) {
-            tables.remove(walker);
+    public void removeWalker(DiagramWalker walker) {
+        if (walker == null) {
+            return;
         }
 
-        firePropertyChange(REMOVE_VCONTENT, null, null);
+        if (walker instanceof WalkerNote) {
+            notes.remove(walker);
+            firePropertyChange(REMOVE_VCONTENT, null, null);
+        } else if (walker instanceof WalkerGroup) {
+            groups.remove(walker);
+            firePropertyChange(REMOVE_VCONTENT, null, null);
+        } else if (walker instanceof ERVirtualTable) {
+            tables.remove(walker);
+            firePropertyChange(REMOVE_VCONTENT, null, null);
+        }
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/note/WalkerNote.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/note/WalkerNote.java
@@ -37,8 +37,8 @@ public class WalkerNote extends DiagramWalker implements Comparable<WalkerNote> 
     @Override
     public List<DiagramWalker> getReferringElementList() {
         final List<DiagramWalker> referringElementList = super.getReferringElementList();
-        for (final WalkerConnection connectionElement : this.getIncomings()) {
-            final DiagramWalker sourceElement = connectionElement.getWalkerSource();
+        for (final WalkerConnection connectionElement : getIncomings()) {
+            final DiagramWalker sourceElement = connectionElement.getSourceWalker();
             referringElementList.add(sourceElement);
         }
         return referringElementList;
@@ -100,7 +100,7 @@ public class WalkerNote extends DiagramWalker implements Comparable<WalkerNote> 
     //                                                                      ==============
     @Override
     public int compareTo(WalkerNote other) {
-        return Format.null2blank(this.noteText).compareTo(Format.null2blank(other.noteText));
+        return Format.null2blank(noteText).compareTo(Format.null2blank(other.noteText));
     }
 
     @Override
@@ -118,7 +118,7 @@ public class WalkerNote extends DiagramWalker implements Comparable<WalkerNote> 
 
     public void setNoteText(String noteText) {
         this.noteText = noteText;
-        this.firePropertyChange(PROPERTY_CHANGE_WALKER_NOTE, null, null);
+        firePropertyChange(PROPERTY_CHANGE_WALKER_NOTE, null, null);
     }
 
     public ERVirtualDiagram getVirtualDiagram() {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/note/WalkerNoteSet.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/note/WalkerNoteSet.java
@@ -16,36 +16,39 @@ public class WalkerNoteSet extends AbstractModel implements ObjectListModel, Ite
     private List<WalkerNote> noteList;
 
     public WalkerNoteSet() {
-        this.noteList = new ArrayList<WalkerNote>();
+        this.noteList = new ArrayList<>();
     }
 
     public void add(WalkerNote note) {
-        this.noteList.add(note);
-        this.firePropertyChange(PROPERTY_CHANGE_WALKER_NOTE_SET, null, null);
+        noteList.add(note);
+        firePropertyChange(PROPERTY_CHANGE_WALKER_NOTE_SET, null, null);
     }
 
     public int remove(WalkerNote note) {
-        final int index = this.noteList.indexOf(note);
-        this.noteList.remove(index);
-        this.firePropertyChange(PROPERTY_CHANGE_WALKER_NOTE_SET, null, null);
+        final int index = noteList.indexOf(note);
+        if (0 < index) {
+            noteList.remove(note);
+        }
+
+        firePropertyChange(PROPERTY_CHANGE_WALKER_NOTE_SET, null, null);
 
         return index;
     }
 
     public List<WalkerNote> getList() {
-        return this.noteList;
+        return noteList;
     }
 
     @Override
     public Iterator<WalkerNote> iterator() {
-        return this.noteList.iterator();
+        return noteList.iterator();
     }
 
     @Override
     public WalkerNoteSet clone() {
         final WalkerNoteSet noteSet = (WalkerNoteSet) super.clone();
-        final List<WalkerNote> newNoteList = new ArrayList<WalkerNote>();
-        for (final WalkerNote note : this.noteList) {
+        final List<WalkerNote> newNoteList = new ArrayList<>();
+        for (final WalkerNote note : noteList) {
             final WalkerNote newNote = (WalkerNote) note.clone();
             newNoteList.add(newNote);
         }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERTable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERTable.java
@@ -54,22 +54,22 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     }
 
     public void addIndex(ERIndex index) {
-        this.indexes.add(index);
+        indexes.add(index);
     }
 
     @Override
     public ERTable copyData() {
         final ERTable to = new ERTable();
 
-        to.setConstraint(this.getConstraint());
-        to.setPrimaryKeyName(this.getPrimaryKeyName());
-        to.setOption(this.getOption());
+        to.setConstraint(getConstraint());
+        to.setPrimaryKeyName(getPrimaryKeyName());
+        to.setOption(getOption());
 
         super.copyTableViewData(to);
 
         final List<ERIndex> indexes = new ArrayList<>();
 
-        for (final ERIndex fromIndex : this.getIndexes()) {
+        for (final ERIndex fromIndex : getIndexes()) {
             indexes.add(new CopyIndex(to, fromIndex, to.getColumns()));
         }
 
@@ -77,13 +77,13 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
 
         final List<CompoundUniqueKey> complexUniqueKeyList = new ArrayList<>();
 
-        for (final CompoundUniqueKey complexUniqueKey : this.getCompoundUniqueKeyList()) {
+        for (final CompoundUniqueKey complexUniqueKey : getCompoundUniqueKeyList()) {
             complexUniqueKeyList.add(new CopyCompoundUniqueKey(complexUniqueKey, to.getColumns()));
         }
 
         to.compoundUniqueKeyList = complexUniqueKeyList;
 
-        to.tableViewProperties = this.getTableViewProperties().clone();
+        to.tableViewProperties = getTableViewProperties().clone();
 
         return to;
     }
@@ -92,15 +92,15 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     public void restructureData(TableView to) {
         final ERTable table = (ERTable) to;
 
-        table.setConstraint(this.getConstraint());
-        table.setPrimaryKeyName(this.getPrimaryKeyName());
-        table.setOption(this.getOption());
+        table.setConstraint(getConstraint());
+        table.setPrimaryKeyName(getPrimaryKeyName());
+        table.setOption(getOption());
 
         super.restructureData(to);
 
         final List<ERIndex> indexes = new ArrayList<>();
 
-        for (final ERIndex fromIndex : this.getIndexes()) {
+        for (final ERIndex fromIndex : getIndexes()) {
             final CopyIndex copyIndex = (CopyIndex) fromIndex;
             final ERIndex restructuredIndex = copyIndex.getRestructuredIndex(table);
             indexes.add(restructuredIndex);
@@ -109,22 +109,22 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
 
         final List<CompoundUniqueKey> complexUniqueKeyList = new ArrayList<>();
 
-        for (final CompoundUniqueKey complexUniqueKey : this.getCompoundUniqueKeyList()) {
+        for (final CompoundUniqueKey complexUniqueKey : getCompoundUniqueKeyList()) {
             final CopyCompoundUniqueKey copyComplexUniqueKey = (CopyCompoundUniqueKey) complexUniqueKey;
-            if (!copyComplexUniqueKey.isRemoved(this.getNormalColumns())) {
+            if (!copyComplexUniqueKey.isRemoved(getNormalColumns())) {
                 final CompoundUniqueKey restructuredComplexUniqueKey = copyComplexUniqueKey.restructure();
                 complexUniqueKeyList.add(restructuredComplexUniqueKey);
             }
         }
         table.compoundUniqueKeyList = complexUniqueKeyList;
 
-        table.tableViewProperties = this.tableViewProperties.clone();
+        table.tableViewProperties = tableViewProperties.clone();
     }
 
     public int getPrimaryKeySize() {
         int count = 0;
 
-        for (final ERColumn column : this.columns) {
+        for (final ERColumn column : columns) {
             if (column instanceof NormalColumn) {
                 final NormalColumn normalColumn = (NormalColumn) column;
 
@@ -140,7 +140,7 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     public List<NormalColumn> getPrimaryKeys() {
         final List<NormalColumn> primaryKeys = new ArrayList<>();
 
-        for (final ERColumn column : this.columns) {
+        for (final ERColumn column : columns) {
             if (column instanceof NormalColumn) {
                 final NormalColumn normalColumn = (NormalColumn) column;
 
@@ -154,15 +154,15 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     }
 
     public boolean isReferable() {
-        if (this.getPrimaryKeySize() > 0) {
+        if (getPrimaryKeySize() > 0) {
             return true;
         }
 
-        if (this.compoundUniqueKeyList.size() > 0) {
+        if (compoundUniqueKeyList.size() > 0) {
             return true;
         }
 
-        for (final ERColumn column : this.columns) {
+        for (final ERColumn column : columns) {
             if (column instanceof NormalColumn) {
                 final NormalColumn normalColumn = (NormalColumn) column;
 
@@ -176,11 +176,11 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     }
 
     public ERIndex getIndex(int index) {
-        return this.indexes.get(index);
+        return indexes.get(index);
     }
 
     public void removeIndex(int index) {
-        this.indexes.remove(index);
+        indexes.remove(index);
     }
 
     public List<ERIndex> getIndexes() {
@@ -190,9 +190,9 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     public void setIndexes(List<ERIndex> indexes) {
         this.indexes = indexes;
 
-        if (this.getDiagram() != null) {
-            this.firePropertyChange(IndexSet.PROPERTY_CHANGE_INDEXES, null, null);
-            this.getDiagram().getDiagramContents().getIndexSet().update();
+        if (getDiagram() != null) {
+            firePropertyChange(IndexSet.PROPERTY_CHANGE_INDEXES, null, null);
+            getDiagram().getDiagramContents().getIndexSet().update();
         }
     }
 
@@ -234,6 +234,11 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
         return new Relationship(referenceForPK, referencedComplexUniqueKey, referencedColumn);
     }
 
+    @Override
+    public ERTable toMaterialize() {
+        return this;
+    }
+
     // ===================================================================================
     //                                                                        TableView ID
     //                                                                        ============
@@ -248,7 +253,7 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     @Override
     public ERTable clone() {
         final ERTable clone = (ERTable) super.clone();
-        final TableProperties cloneTableProperties = (TableProperties) this.getTableViewProperties().clone();
+        final TableProperties cloneTableProperties = (TableProperties) getTableViewProperties().clone();
         clone.tableViewProperties = cloneTableProperties;
         return clone;
     }
@@ -287,14 +292,14 @@ public class ERTable extends TableView implements TablePropertiesHolder, ColumnH
     @Override
     public TableViewProperties getTableViewProperties() {
         this.tableViewProperties =
-                DBManagerFactory.getDBManager(this.getDiagram()).createTableProperties((TableProperties) this.tableViewProperties);
-        return this.tableViewProperties;
+                DBManagerFactory.getDBManager(getDiagram()).createTableProperties((TableProperties) tableViewProperties);
+        return tableViewProperties;
     }
 
     public TableViewProperties getTableViewProperties(String database) {
         this.tableViewProperties =
-                DBManagerFactory.getDBManager(database).createTableProperties((TableProperties) this.tableViewProperties);
-        return this.tableViewProperties;
+                DBManagerFactory.getDBManager(database).createTableProperties((TableProperties) tableViewProperties);
+        return tableViewProperties;
     }
 
     public void setTableViewProperties(TableProperties tableProperties) {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
@@ -81,7 +81,7 @@ public class ERVirtualTable extends ERTable {
         final List<WalkerConnection> connectionList = new ArrayList<>();
         final List<ERVirtualTable> vtables = vdiagram.getVirtualTables();
         for (final WalkerConnection connection : rawTable.getIncomings()) {
-            final DiagramWalker walker = connection.getWalkerSource();
+            final DiagramWalker walker = connection.getSourceWalker();
             if (walker instanceof WalkerNote) {
                 final WalkerNote note = (WalkerNote) walker;
                 if (note.getVirtualDiagram() != null && note.getVirtualDiagram().equals(vdiagram)) {
@@ -104,7 +104,7 @@ public class ERVirtualTable extends ERTable {
         final List<WalkerConnection> connectionList = new ArrayList<>();
         final List<ERVirtualTable> vtables = vdiagram.getVirtualTables();
         for (final WalkerConnection connection : rawTable.getOutgoings()) {
-            final DiagramWalker walker = connection.getWalkerTarget();
+            final DiagramWalker walker = connection.getTargetWalker();
             if (walker instanceof WalkerNote) {
                 if (((WalkerNote) walker).getVirtualDiagram().equals(vdiagram)) {
                     connectionList.add(connection);
@@ -181,7 +181,7 @@ public class ERVirtualTable extends ERTable {
         final List<Relationship> relationships = new ArrayList<>();
         final List<ERVirtualTable> vtables = vdiagram.getVirtualTables();
         for (final Relationship relationship : rawTable.getIncomingRelationshipList()) {
-            final DiagramWalker walker = relationship.getWalkerSource();
+            final DiagramWalker walker = relationship.getSourceWalker();
             for (final ERVirtualTable vtable : vtables) {
                 if (vtable.getRawTable().equals(walker)) {
                     relationships.add(relationship);
@@ -197,7 +197,7 @@ public class ERVirtualTable extends ERTable {
         final List<Relationship> relationships = new ArrayList<>();
         final List<ERVirtualTable> vtables = vdiagram.getVirtualTables();
         for (final Relationship relationship : rawTable.getOutgoingRelationshipList()) {
-            final DiagramWalker walker = relationship.getWalkerSource();
+            final DiagramWalker walker = relationship.getSourceWalker();
             for (final ERVirtualTable vtable : vtables) {
                 if (vtable.getRawTable().equals(walker)) {
                     relationships.add(relationship);

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
@@ -263,6 +263,11 @@ public class ERVirtualTable extends ERTable {
         return rawTable.getNameWithSchema(database);
     }
 
+    @Override
+    public void setColumns(List<ERColumn> columns) {
+        this.rawTable.setColumns(columns);
+    }
+
     // ===================================================================================
     //                                                                            Accessor
     //                                                                            ========

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
@@ -279,6 +279,18 @@ public class ERVirtualTable extends ERTable {
         return rawTable;
     }
 
+    @Override
+    public void changeTableViewProperty(final TableView sourceTableView) {
+        // メインビューを更新（枠の再生成）
+        sourceTableView.restructureData(getRawTable());
+
+        // サブビューも更新
+        changeTable();
+
+        // テーブルの更新（線も含めた再生成）
+        getDiagram().changeTable(sourceTableView);
+    }
+
     // ===================================================================================
     //                                                                      Basic Override
     //                                                                      ==============

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
@@ -275,6 +275,11 @@ public class ERVirtualTable extends ERTable {
         super.setLocation(location);
     }
 
+    @Override
+    public ERTable toMaterialize() {
+        return this.rawTable;
+    }
+
     // ===================================================================================
     //                                                                            Accessor
     //                                                                            ========

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/ERVirtualTable.java
@@ -63,7 +63,7 @@ public class ERVirtualTable extends ERTable {
     }
 
     public void setPoint(int x, int y) {
-        this.setLocation(new Location(x, y, getWidth(), getHeight()));
+        super.setLocation(new Location(x, y, getWidth(), getHeight()));
     }
 
     @Override
@@ -265,7 +265,14 @@ public class ERVirtualTable extends ERTable {
 
     @Override
     public void setColumns(List<ERColumn> columns) {
-        this.rawTable.setColumns(columns);
+        rawTable.setColumns(columns);
+    }
+
+    @Override
+    public void setLocation(Location location) {
+        rawTable.setWidth(location.width);
+        rawTable.setHeight(location.height);
+        super.setLocation(location);
     }
 
     // ===================================================================================

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableSet.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableSet.java
@@ -31,7 +31,7 @@ public class TableSet extends AbstractModel implements ObjectListModel, Iterable
     //                                                                         Constructor
     //                                                                         ===========
     public TableSet() {
-        this.tableList = new ArrayList<ERTable>();
+        this.tableList = new ArrayList<>();
     }
 
     // ===================================================================================
@@ -44,13 +44,17 @@ public class TableSet extends AbstractModel implements ObjectListModel, Iterable
 
     public int remove(ERTable table) {
         final int index = tableList.indexOf(table);
-        tableList.remove(index);
+        if (0 < index) {
+            tableList.remove(index);
+        }
+
         firePropertyChange(PROPERTY_CHANGE_TABLE_SET, null, null);
+
         return index;
     }
 
     public void setDirty() {
-        this.firePropertyChange(PROPERTY_CHANGE_TABLE_SET, null, null);
+        firePropertyChange(PROPERTY_CHANGE_TABLE_SET, null, null);
     }
 
     public List<ERTable> getList() {
@@ -59,7 +63,7 @@ public class TableSet extends AbstractModel implements ObjectListModel, Iterable
     }
 
     public List<String> getAutoSequenceNames(String database) {
-        final List<String> autoSequenceNames = new ArrayList<String>();
+        final List<String> autoSequenceNames = new ArrayList<>();
         for (final ERTable table : tableList) {
             final String prefix = table.getNameWithSchema(database) + "_";
             for (final NormalColumn column : table.getNormalColumns()) {
@@ -83,13 +87,13 @@ public class TableSet extends AbstractModel implements ObjectListModel, Iterable
     @Override
     public Iterator<ERTable> iterator() {
         Collections.sort(tableList);
-        return this.tableList.iterator();
+        return tableList.iterator();
     }
 
     @Override
     public TableSet clone() {
         final TableSet tableSet = (TableSet) super.clone();
-        final List<ERTable> newTableList = new ArrayList<ERTable>();
+        final List<ERTable> newTableList = new ArrayList<>();
         for (final ERTable table : tableList) {
             final ERTable newTable = table.clone();
             newTableList.add(newTable);

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableView.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableView.java
@@ -117,7 +117,7 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
     }
 
     public void removeColumn(ERColumn column) {
-        this.columns.remove(column);
+        this.getColumns().remove(column);
         this.firePropertyChange(PROPERTY_CHANGE_COLUMNS, null, null);
     }
 

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableView.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableView.java
@@ -105,13 +105,13 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
     }
 
     public void addColumn(ERColumn column) {
-        this.columns.add(column);
+        this.getColumns().add(column);
         column.setColumnHolder(this);
         this.firePropertyChange(PROPERTY_CHANGE_COLUMNS, null, null);
     }
 
     public void addColumn(int index, ERColumn column) {
-        this.columns.add(index, column);
+        this.getColumns().add(index, column);
         column.setColumnHolder(this);
         this.firePropertyChange(PROPERTY_CHANGE_COLUMNS, null, null);
     }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableView.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/TableView.java
@@ -54,7 +54,7 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
     //                                                                         Constructor
     //                                                                         ===========
     public TableView() {
-        this.columns = new ArrayList<ERColumn>();
+        this.columns = new ArrayList<>();
     }
 
     // ===================================================================================
@@ -77,7 +77,7 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
     //                                                                              Column
     //                                                                              ======
     public List<NormalColumn> getNormalColumns() {
-        final List<NormalColumn> normalColumns = new ArrayList<NormalColumn>();
+        final List<NormalColumn> normalColumns = new ArrayList<>();
         for (final ERColumn column : columns) {
             if (column instanceof NormalColumn) {
                 normalColumns.add((NormalColumn) column);
@@ -87,7 +87,7 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
     }
 
     public List<NormalColumn> getExpandedColumns() {
-        final List<NormalColumn> expandedColumns = new ArrayList<NormalColumn>();
+        final List<NormalColumn> expandedColumns = new ArrayList<>();
         for (final ERColumn column : this.getColumns()) {
             if (column instanceof NormalColumn) {
                 final NormalColumn normalColumn = (NormalColumn) column;
@@ -139,7 +139,7 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
         to.setPhysicalName(getPhysicalName());
         to.setLogicalName(getLogicalName());
         to.setDescription(getDescription());
-        final List<ERColumn> columns = new ArrayList<ERColumn>();
+        final List<ERColumn> columns = new ArrayList<>();
         for (final ERColumn fromColumn : getColumns()) {
             if (fromColumn instanceof NormalColumn) {
                 final NormalColumn normalColumn = (NormalColumn) fromColumn;
@@ -174,9 +174,13 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
         for (final NormalColumn toColumn : to.getNormalColumns()) {
             dictionary.remove(toColumn);
         }
-        final List<ERColumn> columns = new ArrayList<ERColumn>();
-        final List<NormalColumn> newPrimaryKeyColumns = new ArrayList<NormalColumn>();
+        final List<ERColumn> columns = new ArrayList<>();
+        final List<NormalColumn> newPrimaryKeyColumns = new ArrayList<>();
         for (final ERColumn fromColumn : getColumns()) {
+            if (columns.stream().anyMatch(c -> c.same(fromColumn))) {
+                // 同一テーブル同一カラムだった場合、無視する。
+                continue;
+            }
             if (fromColumn instanceof NormalColumn) {
                 final CopyColumn copyColumn = (CopyColumn) fromColumn;
                 CopyWord copyWord = copyColumn.getWord();
@@ -257,7 +261,7 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
     }
 
     public List<Relationship> getIncomingRelationshipList() {
-        final List<Relationship> relations = new ArrayList<Relationship>();
+        final List<Relationship> relations = new ArrayList<>();
         for (final WalkerConnection connection : getIncomings()) {
             if (connection instanceof Relationship) {
                 relations.add((Relationship) connection);
@@ -267,7 +271,7 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
     }
 
     public List<Relationship> getOutgoingRelationshipList() {
-        final List<Relationship> relations = new ArrayList<Relationship>();
+        final List<Relationship> relations = new ArrayList<>();
         for (final WalkerConnection connection : getOutgoings()) {
             if (connection instanceof Relationship) {
                 relations.add((Relationship) connection);
@@ -454,5 +458,14 @@ public abstract class TableView extends DiagramWalker implements ObjectModel, Co
 
     public TableViewProperties getTableViewProperties() {
         return tableViewProperties;
+    }
+
+    public void changeTableViewProperty(final TableView sourceTableView) {
+        // メインビューを更新
+        sourceTableView.restructureData(this);
+        this.getDiagram().changeTable(sourceTableView);
+
+        // サブビューも更新
+        this.getDiagram().doChangeTable(sourceTableView);
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/ColumnHolder.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/ColumnHolder.java
@@ -5,6 +5,9 @@ public interface ColumnHolder {
     String getName();
 
     default boolean same(ColumnHolder columnHolder) {
+        if (columnHolder == null) {
+            return false;
+        }
         return getName().equals(columnHolder.getName());
     }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/ColumnHolder.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/ColumnHolder.java
@@ -3,4 +3,8 @@ package org.dbflute.erflute.editor.model.diagram_contents.element.node.table.col
 public interface ColumnHolder {
 
     String getName();
+
+    default boolean same(ColumnHolder columnHolder) {
+        return getName().equals(columnHolder.getName());
+    }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/ERColumn.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/ERColumn.java
@@ -20,4 +20,8 @@ public abstract class ERColumn extends AbstractModel {
     public ColumnHolder getColumnHolder() {
         return this.columnHolder;
     }
+
+    public boolean same(ERColumn erColumn) {
+        return this.columnHolder.same(erColumn.columnHolder) && getName().equals(erColumn.getName());
+    }
 }

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/NormalColumn.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/NormalColumn.java
@@ -171,6 +171,11 @@ public class NormalColumn extends ERColumn {
     }
 
     public void addReference(NormalColumn referredColumn, Relationship relationship) {
+        // 参照列とリレーションが重複して追加されることがあるため、ここでガードする。
+        if (referredColumnList.contains(referredColumn) || relationshipList.contains(relationship)) {
+            return;
+        }
+
         this.foreignKeyDescription = getDescription();
         this.foreignKeyLogicalName = getLogicalName();
         this.foreignKeyPhysicalName = getPhysicalName();

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/NormalColumn.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/NormalColumn.java
@@ -37,8 +37,8 @@ public class NormalColumn extends ERColumn {
     private String uniqueKeyName;
     private String characterSet;
     private String collation;
-    private List<NormalColumn> referredColumnList = new ArrayList<NormalColumn>();
-    private List<Relationship> relationshipList = new ArrayList<Relationship>();
+    private List<NormalColumn> referredColumnList = new ArrayList<>();
+    private List<Relationship> relationshipList = new ArrayList<>();
     private Sequence autoIncrementSetting; // same as sequence
 
     // ===================================================================================
@@ -57,8 +57,8 @@ public class NormalColumn extends ERColumn {
         this.foreignKeyPhysicalName = from.foreignKeyPhysicalName;
         this.foreignKeyLogicalName = from.foreignKeyLogicalName;
         this.foreignKeyDescription = from.foreignKeyDescription;
-        this.init(from.notNull, from.primaryKey, from.uniqueKey, from.autoIncrement, from.defaultValue, from.constraint,
-                from.uniqueKeyName, from.characterSet, from.collation);
+        this.init(from.notNull, from.primaryKey, from.uniqueKey, from.autoIncrement, from.defaultValue, from.constraint, from.uniqueKeyName,
+                from.characterSet, from.collation);
         this.word = from.word;
         this.autoIncrementSetting = (Sequence) from.autoIncrementSetting.clone();
     }
@@ -67,6 +67,14 @@ public class NormalColumn extends ERColumn {
         this.word = null;
         this.referredColumnList.add(referredColumn);
         this.relationshipList.add(relationship);
+        copyData(from, this);
+        this.primaryKey = primaryKey;
+        this.autoIncrement = false;
+        this.autoIncrementSetting = new Sequence();
+    }
+
+    public NormalColumn(NormalColumn from, boolean primaryKey) {
+        this.word = (Word) from.getWord().clone();
         copyData(from, this);
         this.primaryKey = primaryKey;
         this.autoIncrement = false;
@@ -113,7 +121,7 @@ public class NormalColumn extends ERColumn {
     }
 
     public List<Relationship> getOutgoingRelationList() {
-        final List<Relationship> outgoingRelationList = new ArrayList<Relationship>();
+        final List<Relationship> outgoingRelationList = new ArrayList<>();
         final ColumnHolder columnHolder = this.getColumnHolder();
         if (columnHolder instanceof ERTable) {
             final ERTable table = (ERTable) columnHolder;
@@ -133,7 +141,7 @@ public class NormalColumn extends ERColumn {
     }
 
     public List<NormalColumn> getForeignKeyList() {
-        final List<NormalColumn> foreignKeyList = new ArrayList<NormalColumn>();
+        final List<NormalColumn> foreignKeyList = new ArrayList<>();
         final ColumnHolder columnHolder = this.getColumnHolder();
         if (columnHolder instanceof ERTable) {
             final ERTable table = (ERTable) columnHolder;
@@ -166,14 +174,14 @@ public class NormalColumn extends ERColumn {
         this.foreignKeyDescription = getDescription();
         this.foreignKeyLogicalName = getLogicalName();
         this.foreignKeyPhysicalName = getPhysicalName();
-        this.referredColumnList.add(referredColumn);
-        this.relationshipList.add(relationship);
+        referredColumnList.add(referredColumn);
+        relationshipList.add(relationship);
         copyData(this, this);
         this.word = null;
     }
 
     public void renewRelationList() {
-        final List<Relationship> newRelationList = new ArrayList<Relationship>();
+        final List<Relationship> newRelationList = new ArrayList<>();
         newRelationList.addAll(this.relationshipList);
         this.relationshipList = newRelationList;
     }
@@ -363,8 +371,8 @@ public class NormalColumn extends ERColumn {
     @Override
     public NormalColumn clone() {
         final NormalColumn clone = (NormalColumn) super.clone();
-        clone.relationshipList = new ArrayList<Relationship>(this.relationshipList);
-        clone.referredColumnList = new ArrayList<NormalColumn>(this.referredColumnList);
+        clone.relationshipList = new ArrayList<>(this.relationshipList);
+        clone.referredColumnList = new ArrayList<>(this.referredColumnList);
         return clone;
     }
 
@@ -557,7 +565,7 @@ public class NormalColumn extends ERColumn {
     }
 
     public void clearRelations() {
-        relationshipList = new ArrayList<Relationship>();
+        relationshipList = new ArrayList<>();
     }
 
     public Sequence getAutoIncrementSetting() {

--- a/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/NormalColumn.java
+++ b/src/org/dbflute/erflute/editor/model/diagram_contents/element/node/table/column/NormalColumn.java
@@ -47,17 +47,17 @@ public class NormalColumn extends ERColumn {
     public NormalColumn(Word word, boolean notNull, boolean primaryKey, boolean uniqueKey, boolean autoIncrement, String defaultValue,
             String constraint, String uniqueKeyName, String characterSet, String collation) {
         this.word = word;
-        this.init(notNull, primaryKey, uniqueKey, autoIncrement, defaultValue, constraint, uniqueKeyName, characterSet, collation);
+        init(notNull, primaryKey, uniqueKey, autoIncrement, defaultValue, constraint, uniqueKeyName, characterSet, collation);
         this.autoIncrementSetting = new Sequence();
     }
 
     protected NormalColumn(NormalColumn from) {
-        this.referredColumnList.addAll(from.referredColumnList);
-        this.relationshipList.addAll(from.relationshipList);
+        referredColumnList.addAll(from.referredColumnList);
+        relationshipList.addAll(from.relationshipList);
         this.foreignKeyPhysicalName = from.foreignKeyPhysicalName;
         this.foreignKeyLogicalName = from.foreignKeyLogicalName;
         this.foreignKeyDescription = from.foreignKeyDescription;
-        this.init(from.notNull, from.primaryKey, from.uniqueKey, from.autoIncrement, from.defaultValue, from.constraint, from.uniqueKeyName,
+        init(from.notNull, from.primaryKey, from.uniqueKey, from.autoIncrement, from.defaultValue, from.constraint, from.uniqueKeyName,
                 from.characterSet, from.collation);
         this.word = from.word;
         this.autoIncrementSetting = (Sequence) from.autoIncrementSetting.clone();
@@ -65,16 +65,8 @@ public class NormalColumn extends ERColumn {
 
     public NormalColumn(NormalColumn from, NormalColumn referredColumn, Relationship relationship, boolean primaryKey) {
         this.word = null;
-        this.referredColumnList.add(referredColumn);
-        this.relationshipList.add(relationship);
-        copyData(from, this);
-        this.primaryKey = primaryKey;
-        this.autoIncrement = false;
-        this.autoIncrementSetting = new Sequence();
-    }
-
-    public NormalColumn(NormalColumn from, boolean primaryKey) {
-        this.word = (Word) from.getWord().clone();
+        referredColumnList.add(referredColumn);
+        relationshipList.add(relationship);
         copyData(from, this);
         this.primaryKey = primaryKey;
         this.autoIncrement = false;
@@ -122,12 +114,12 @@ public class NormalColumn extends ERColumn {
 
     public List<Relationship> getOutgoingRelationList() {
         final List<Relationship> outgoingRelationList = new ArrayList<>();
-        final ColumnHolder columnHolder = this.getColumnHolder();
+        final ColumnHolder columnHolder = getColumnHolder();
         if (columnHolder instanceof ERTable) {
             final ERTable table = (ERTable) columnHolder;
             for (final Relationship relation : table.getOutgoingRelationshipList()) {
                 if (relation.isReferenceForPK()) {
-                    if (this.isPrimaryKey()) {
+                    if (isPrimaryKey()) {
                         outgoingRelationList.add(relation);
                     }
                 } else {
@@ -142,7 +134,7 @@ public class NormalColumn extends ERColumn {
 
     public List<NormalColumn> getForeignKeyList() {
         final List<NormalColumn> foreignKeyList = new ArrayList<>();
-        final ColumnHolder columnHolder = this.getColumnHolder();
+        final ColumnHolder columnHolder = getColumnHolder();
         if (columnHolder instanceof ERTable) {
             final ERTable table = (ERTable) columnHolder;
             for (final Relationship relation : table.getOutgoingRelationshipList()) {
@@ -187,34 +179,35 @@ public class NormalColumn extends ERColumn {
 
     public void renewRelationList() {
         final List<Relationship> newRelationList = new ArrayList<>();
-        newRelationList.addAll(this.relationshipList);
+        newRelationList.addAll(relationshipList);
         this.relationshipList = newRelationList;
     }
 
     public void removeReference(Relationship relation) {
-        this.relationshipList.remove(relation);
+        relationshipList.remove(relation);
         if (relationshipList.isEmpty()) {
-            NormalColumn temp = this.getFirstReferredColumn();
+            NormalColumn temp = getFirstReferredColumn();
             while (temp.isForeignKey()) {
                 temp = temp.getFirstReferredColumn();
             }
             this.word = temp.getWord();
-            if (this.getPhysicalName() != this.word.getPhysicalName() || this.getLogicalName() != this.word.getLogicalName()
-                    || this.getDescription() != this.word.getDescription()) {
-                this.word = new Word(this.word);
-                this.word.setPhysicalName(this.getPhysicalName());
-                this.word.setLogicalName(this.getLogicalName());
-                this.word.setDescription(this.getDescription());
+            if (getPhysicalName() != word.getPhysicalName()
+                    || getLogicalName() != word.getLogicalName()
+                    || getDescription() != word.getDescription()) {
+                this.word = new Word(word);
+                word.setPhysicalName(getPhysicalName());
+                word.setLogicalName(getLogicalName());
+                word.setDescription(getDescription());
             }
             this.foreignKeyDescription = null;
             this.foreignKeyLogicalName = null;
             this.foreignKeyPhysicalName = null;
-            this.referredColumnList.clear();
+            referredColumnList.clear();
             copyData(this, this);
         } else {
-            for (final NormalColumn referencedColumn : this.referredColumnList) {
+            for (final NormalColumn referencedColumn : referredColumnList) {
                 if (referencedColumn.getColumnHolder() == relation.getSourceTableView()) {
-                    this.referredColumnList.remove(referencedColumn);
+                    referredColumnList.remove(referencedColumn);
                     break;
                 }
             }
@@ -222,18 +215,18 @@ public class NormalColumn extends ERColumn {
     }
 
     public boolean isForeignKey() {
-        if (!this.relationshipList.isEmpty()) {
+        if (!relationshipList.isEmpty()) {
             return true;
         }
         return false;
     }
 
     public boolean isRefered() {
-        if (!(this.getColumnHolder() instanceof ERTable)) {
+        if (!(getColumnHolder() instanceof ERTable)) {
             return false;
         }
         boolean isRefered = false;
-        final ERTable table = (ERTable) this.getColumnHolder();
+        final ERTable table = (ERTable) getColumnHolder();
         for (final Relationship relation : table.getOutgoingRelationshipList()) {
             if (!relation.isReferenceForPK()) {
                 for (final NormalColumn foreignKeyColumn : relation.getForeignKeyColumns()) {
@@ -256,11 +249,11 @@ public class NormalColumn extends ERColumn {
     }
 
     public boolean isReferedStrictly() {
-        if (!(this.getColumnHolder() instanceof ERTable)) {
+        if (!(getColumnHolder() instanceof ERTable)) {
             return false;
         }
         boolean isRefered = false;
-        final ERTable table = (ERTable) this.getColumnHolder();
+        final ERTable table = (ERTable) getColumnHolder();
         for (final Relationship relation : table.getOutgoingRelationshipList()) {
             if (!relation.isReferenceForPK()) {
                 for (final NormalColumn foreignKeyColumn : relation.getForeignKeyColumns()) {
@@ -278,7 +271,7 @@ public class NormalColumn extends ERColumn {
                     break;
                 }
             } else {
-                if (this.isPrimaryKey()) {
+                if (isPrimaryKey()) {
                     isRefered = true;
                     break;
                 }
@@ -288,11 +281,11 @@ public class NormalColumn extends ERColumn {
     }
 
     public Word getWord() {
-        return this.word;
+        return word;
     }
 
     public boolean isFullTextIndexable() {
-        return this.getType().isFullTextIndexable();
+        return getType().isFullTextIndexable();
     }
 
     public static void copyData(NormalColumn from, NormalColumn to) {
@@ -376,8 +369,8 @@ public class NormalColumn extends ERColumn {
     @Override
     public NormalColumn clone() {
         final NormalColumn clone = (NormalColumn) super.clone();
-        clone.relationshipList = new ArrayList<>(this.relationshipList);
-        clone.referredColumnList = new ArrayList<>(this.referredColumnList);
+        clone.relationshipList = new ArrayList<>(relationshipList);
+        clone.referredColumnList = new ArrayList<>(referredColumnList);
         return clone;
     }
 
@@ -400,40 +393,40 @@ public class NormalColumn extends ERColumn {
     }
 
     public String getPhysicalName() {
-        if (this.getFirstReferredColumn() != null) {
-            if (!Check.isEmpty(this.foreignKeyPhysicalName)) {
-                return this.foreignKeyPhysicalName;
+        if (getFirstReferredColumn() != null) {
+            if (!Check.isEmpty(foreignKeyPhysicalName)) {
+                return foreignKeyPhysicalName;
             } else {
-                return this.getFirstReferredColumn().getPhysicalName();
+                return getFirstReferredColumn().getPhysicalName();
             }
         }
-        return this.word.getPhysicalName();
+        return word.getPhysicalName();
     }
 
     public String getLogicalName() {
-        if (this.getFirstReferredColumn() != null) {
-            if (!Check.isEmpty(this.foreignKeyLogicalName)) {
-                return this.foreignKeyLogicalName;
+        if (getFirstReferredColumn() != null) {
+            if (!Check.isEmpty(foreignKeyLogicalName)) {
+                return foreignKeyLogicalName;
             } else {
-                return this.getFirstReferredColumn().getLogicalName();
+                return getFirstReferredColumn().getLogicalName();
             }
         }
-        return this.word.getLogicalName();
+        return word.getLogicalName();
     }
 
     public String getDescription() {
-        if (this.getFirstReferredColumn() != null) {
-            if (!Check.isEmpty(this.foreignKeyDescription)) {
-                return this.foreignKeyDescription;
+        if (getFirstReferredColumn() != null) {
+            if (!Check.isEmpty(foreignKeyDescription)) {
+                return foreignKeyDescription;
             } else {
-                return this.getFirstReferredColumn().getDescription();
+                return getFirstReferredColumn().getDescription();
             }
         }
-        return this.word.getDescription();
+        return word.getDescription();
     }
 
     public String getForeignKeyLogicalName() {
-        return this.foreignKeyLogicalName;
+        return foreignKeyLogicalName;
     }
 
     public String getForeignKeyPhysicalName() {
@@ -445,8 +438,8 @@ public class NormalColumn extends ERColumn {
     }
 
     public SqlType getType() {
-        if (this.getFirstReferredColumn() != null) {
-            final SqlType type = this.getFirstReferredColumn().getType();
+        if (getFirstReferredColumn() != null) {
+            final SqlType type = getFirstReferredColumn().getType();
             if (SqlType.valueOfId(SqlType.SQL_TYPE_ID_SERIAL).equals(type)) {
                 return SqlType.valueOfId(SqlType.SQL_TYPE_ID_INTEGER);
             } else if (SqlType.valueOfId(SqlType.SQL_TYPE_ID_BIG_SERIAL).equals(type)) {
@@ -458,34 +451,34 @@ public class NormalColumn extends ERColumn {
     }
 
     public TypeData getTypeData() {
-        if (this.getFirstReferredColumn() != null) {
+        if (getFirstReferredColumn() != null) {
             return getFirstReferredColumn().getTypeData();
         }
-        return this.word.getTypeData();
+        return word.getTypeData();
     }
 
     public boolean isNotNull() {
-        return this.notNull;
+        return notNull;
     }
 
     public boolean isPrimaryKey() {
-        return this.primaryKey;
+        return primaryKey;
     }
 
     public boolean isUniqueKey() {
-        return this.uniqueKey;
+        return uniqueKey;
     }
 
     public boolean isAutoIncrement() {
-        return this.autoIncrement;
+        return autoIncrement;
     }
 
     public String getDefaultValue() {
-        return this.defaultValue;
+        return defaultValue;
     }
 
     public String getConstraint() {
-        return this.constraint;
+        return constraint;
     }
 
     public String getUniqueKeyName() {
@@ -553,16 +546,16 @@ public class NormalColumn extends ERColumn {
     }
 
     public void copyForeikeyData(NormalColumn to) {
-        to.setConstraint(this.getConstraint());
-        to.setForeignKeyDescription(this.getForeignKeyDescription());
-        to.setForeignKeyLogicalName(this.getForeignKeyLogicalName());
-        to.setForeignKeyPhysicalName(this.getForeignKeyPhysicalName());
-        to.setNotNull(this.isNotNull());
-        to.setUniqueKey(this.isUniqueKey());
-        to.setPrimaryKey(this.isPrimaryKey());
-        to.setAutoIncrement(this.isAutoIncrement());
-        to.setCharacterSet(this.getCharacterSet());
-        to.setCollation(this.getCollation());
+        to.setConstraint(getConstraint());
+        to.setForeignKeyDescription(getForeignKeyDescription());
+        to.setForeignKeyLogicalName(getForeignKeyLogicalName());
+        to.setForeignKeyPhysicalName(getForeignKeyPhysicalName());
+        to.setNotNull(isNotNull());
+        to.setUniqueKey(isUniqueKey());
+        to.setPrimaryKey(isPrimaryKey());
+        to.setAutoIncrement(isAutoIncrement());
+        to.setCharacterSet(getCharacterSet());
+        to.setCollation(getCollation());
     }
 
     public List<NormalColumn> getReferencedColumnList() {

--- a/src/org/dbflute/erflute/editor/model/edit/CopyManager.java
+++ b/src/org/dbflute/erflute/editor/model/edit/CopyManager.java
@@ -30,7 +30,6 @@ import org.dbflute.erflute.editor.model.settings.DiagramSettings;
 public class CopyManager {
 
     private static DiagramWalkerSet copyList = new DiagramWalkerSet();
-
     private static int numberOfCopy;
 
     private Map<DiagramWalker, DiagramWalker> walkerMap;
@@ -77,7 +76,7 @@ public class CopyManager {
                 continue;
             }
             final DiagramWalker cloneNodeElement = walker.clone();
-            copyList.addDiagramWalker(cloneNodeElement);
+            copyList.add(cloneNodeElement);
             walkerMap.put(walker, cloneNodeElement);
             if (walker instanceof ERTable) {
                 copyColumnAndIndex((ERTable) walker, (ERTable) cloneNodeElement, columnMap, complexUniqueKeyMap);
@@ -118,7 +117,6 @@ public class CopyManager {
                                     }
 
                                     NormalColumn targetReferencedColumn = null;
-
                                     for (final NormalColumn referencedColumn : oldColumn.getReferencedColumnList()) {
                                         if (referencedColumn.getColumnHolder() == oldRelation.getSourceTableView()) {
                                             targetReferencedColumn = referencedColumn;
@@ -129,7 +127,6 @@ public class CopyManager {
 
                                     newColumn.removeReference(oldRelation);
                                     newColumn.addReference(newReferencedColumn, newRelation);
-
                                 } else {
                                     // 複製先の列を外部キーではなく、通常の列に作り直します
                                     newColumn.removeReference(oldRelation);
@@ -144,8 +141,8 @@ public class CopyManager {
         return copyList;
     }
 
-    private static void replaceIncoming(DiagramWalker from, DiagramWalker to, Map<WalkerConnection, WalkerConnection> connectionElementMap,
-            Map<DiagramWalker, DiagramWalker> nodeElementMap) {
+    private static void replaceIncoming(DiagramWalker from, DiagramWalker to,
+            Map<WalkerConnection, WalkerConnection> connectionElementMap, Map<DiagramWalker, DiagramWalker> nodeElementMap) {
         final List<WalkerConnection> cloneIncomings = new ArrayList<>();
         for (final WalkerConnection incoming : from.getIncomings()) {
             final DiagramWalker oldSource = incoming.getWalkerSource();
@@ -162,8 +159,8 @@ public class CopyManager {
         to.setIncoming(cloneIncomings);
     }
 
-    private static void copyColumnAndIndex(ERTable from, ERTable to, Map<ERColumn, ERColumn> columnMap,
-            Map<CompoundUniqueKey, CompoundUniqueKey> complexUniqueKeyMap) {
+    private static void copyColumnAndIndex(ERTable from, ERTable to,
+            Map<ERColumn, ERColumn> columnMap, Map<CompoundUniqueKey, CompoundUniqueKey> complexUniqueKeyMap) {
         copyColumn(from, to, columnMap);
         copyIndex(from, to, columnMap);
         copyComplexUniqueKey(from, to, columnMap, complexUniqueKeyMap);
@@ -188,8 +185,8 @@ public class CopyManager {
         to.setColumns(cloneColumns);
     }
 
-    private static void copyComplexUniqueKey(ERTable from, ERTable to, Map<ERColumn, ERColumn> columnMap,
-            Map<CompoundUniqueKey, CompoundUniqueKey> complexUniqueKeyMap) {
+    private static void copyComplexUniqueKey(ERTable from, ERTable to,
+            Map<ERColumn, ERColumn> columnMap, Map<CompoundUniqueKey, CompoundUniqueKey> complexUniqueKeyMap) {
         final List<CompoundUniqueKey> cloneComplexUniqueKeyList = new ArrayList<>();
 
         // 元のテーブルの複合一意キーに対して、処理を繰り返します。
@@ -247,20 +244,20 @@ public class CopyManager {
     public DiagramContents copy(DiagramContents originalDiagramContents) {
         final DiagramContents copyDiagramContents = new DiagramContents();
 
-        copyDiagramContents.setDiagramWalkers(this.copyNodeElementList(originalDiagramContents.getDiagramWalkers()));
-        final Map<DiagramWalker, DiagramWalker> nodeElementMap = this.getNodeElementMap();
+        copyDiagramContents.setDiagramWalkers(copyNodeElementList(originalDiagramContents.getDiagramWalkers()));
+        final Map<DiagramWalker, DiagramWalker> nodeElementMap = getNodeElementMap();
 
         final DiagramSettings settings = (DiagramSettings) originalDiagramContents.getSettings().clone();
-        this.setSettings(nodeElementMap, settings);
+        setSettings(nodeElementMap, settings);
         copyDiagramContents.setSettings(settings);
 
-        this.setColumnGroup(copyDiagramContents, originalDiagramContents);
+        setColumnGroup(copyDiagramContents, originalDiagramContents);
 
         copyDiagramContents.setSequenceSet(originalDiagramContents.getSequenceSet().clone());
         copyDiagramContents.setTriggerSet(originalDiagramContents.getTriggerSet().clone());
 
-        this.setWord(copyDiagramContents, originalDiagramContents);
-        this.setTablespace(copyDiagramContents, originalDiagramContents);
+        setWord(copyDiagramContents, originalDiagramContents);
+        setTablespace(copyDiagramContents, originalDiagramContents);
 
         return copyDiagramContents;
     }
@@ -277,7 +274,6 @@ public class CopyManager {
     }
 
     private void setColumnGroup(DiagramContents copyDiagramContents, DiagramContents originalDiagramContents) {
-
         final Map<ColumnGroup, ColumnGroup> columnGroupMap = new HashMap<>();
 
         for (final ColumnGroup columnGroup : originalDiagramContents.getColumnGroupSet()) {
@@ -293,7 +289,6 @@ public class CopyManager {
             for (final ERColumn column : tableView.getColumns()) {
                 if (column instanceof ColumnGroup) {
                     newColumns.add(columnGroupMap.get(column));
-
                 } else {
                     newColumns.add(column);
                 }
@@ -304,7 +299,6 @@ public class CopyManager {
     }
 
     private void setWord(DiagramContents copyDiagramContents, DiagramContents originalDiagramContents) {
-
         final Map<Word, Word> wordMap = new HashMap<>();
         final Dictionary copyDictionary = copyDiagramContents.getDictionary();
 
@@ -339,7 +333,6 @@ public class CopyManager {
     }
 
     private void setTablespace(DiagramContents copyDiagramContents, DiagramContents originalDiagramContents) {
-
         final Map<Tablespace, Tablespace> tablespaceMap = new HashMap<>();
         final TablespaceSet copyTablespaceSet = copyDiagramContents.getTablespaceSet();
 

--- a/src/org/dbflute/erflute/editor/model/edit/CopyManager.java
+++ b/src/org/dbflute/erflute/editor/model/edit/CopyManager.java
@@ -145,7 +145,7 @@ public class CopyManager {
             Map<WalkerConnection, WalkerConnection> connectionElementMap, Map<DiagramWalker, DiagramWalker> nodeElementMap) {
         final List<WalkerConnection> cloneIncomings = new ArrayList<>();
         for (final WalkerConnection incoming : from.getIncomings()) {
-            final DiagramWalker oldSource = incoming.getWalkerSource();
+            final DiagramWalker oldSource = incoming.getSourceWalker();
             final DiagramWalker newSource = nodeElementMap.get(oldSource);
             if (newSource != null) {
                 final WalkerConnection cloneIncoming = incoming.clone();

--- a/src/org/dbflute/erflute/editor/persistent/xml/reader/ErmXmlReader.java
+++ b/src/org/dbflute/erflute/editor/persistent/xml/reader/ErmXmlReader.java
@@ -115,7 +115,7 @@ public class ErmXmlReader {
             root = document.getFirstChild();
         }
         load((Element) root);
-        return this.diagram;
+        return diagram;
     }
 
     // ===================================================================================
@@ -183,13 +183,13 @@ public class ErmXmlReader {
             final String walkerName = walkerNode.getNodeName();
             if ("table".equals(walkerName)) {
                 final ERTable table = tableLoader.loadTable((Element) walkerNode, context, diagram, database);
-                contents.addDiagramWalker(table);
+                contents.add(table);
             } else if ("view".equals(walkerName)) {
                 final ERView view = viewLoader.loadView((Element) walkerNode, context, diagram, database);
-                contents.addDiagramWalker(view);
+                contents.add(view);
             } else if ("walker_note".equals(walkerName) || "note".equals(walkerName)) { // #for_erflute
                 final WalkerNote note = walkerNoteLoader.loadNote((Element) walkerNode, context);
-                contents.addDiagramWalker(note);
+                contents.add(note);
             } else if ("walker_group".equals(walkerName) || "group".equals(walkerName)) { // #for_erflute
                 final WalkerGroup group = walkerGroupLoader.loadGroup((Element) walkerNode, context, new WalkerGroupedTableViewProvider() {
                     @Override
@@ -197,10 +197,10 @@ public class ErmXmlReader {
                         return diagram.getDiagramContents().getDiagramWalkers().getTableViewList();
                     }
                 });
-                contents.addDiagramWalker(group);
+                contents.add(group);
             } else if ("inserted_image".equals(walkerName) || "image".equals(walkerName)) { // #for_erflute
                 final InsertedImage insertedImage = insertedImageLoader.loadInsertedImage((Element) walkerNode, context);
-                contents.addDiagramWalker(insertedImage);
+                contents.add(insertedImage);
             } else {
                 throw new IllegalStateException("*Unsupported contents: " + walkerNode);
             }

--- a/src/org/dbflute/erflute/editor/persistent/xml/reader/ReadAssistLogic.java
+++ b/src/org/dbflute/erflute/editor/persistent/xml/reader/ReadAssistLogic.java
@@ -76,10 +76,17 @@ public class ReadAssistLogic {
     //                                                                            Location
     //                                                                            ========
     public void loadLocation(DiagramWalker nodeElement, Element element) {
+        loadLocation(nodeElement, element, -1, -1);
+    }
+
+    // コミット：5b7e3a9763b39a20c78f1371c78b1fd2db46a846により、仮想ダイアグラム上でのテーブルサイズ変更をrawTableに反映するようにした。
+    // ファイルからのロード時、この変更によりelementにwidth、heightが設定されていないと、rawTableのwidth、heightが-1に設定されてしまう。
+    // このバグを回避するために、以下オーバーロードを追加した。
+    public void loadLocation(DiagramWalker nodeElement, Element element, int defaultWidth, int defaultHeight) {
         final int x = getIntValue(element, "x");
         final int y = getIntValue(element, "y");
-        final int width = getIntValue(element, "width", -1);
-        final int height = getIntValue(element, "height", -1);
+        final int width = getIntValue(element, "width", defaultWidth);
+        final int height = getIntValue(element, "height", defaultHeight);
         nodeElement.setLocation(new Location(x, y, width, height));
     }
 

--- a/src/org/dbflute/erflute/editor/persistent/xml/reader/ReadTableLoader.java
+++ b/src/org/dbflute/erflute/editor/persistent/xml/reader/ReadTableLoader.java
@@ -87,7 +87,7 @@ public class ReadTableLoader {
         final ERTable rawTable = (ERTable) context.walkerMap.get(tableId);
         assertRawTableExists(vdiagram, context, tableId, rawTable);
         final ERVirtualTable vtable = new ERVirtualTable(vdiagram, rawTable);
-        assistLogic.loadLocation(vtable, element);
+        assistLogic.loadLocation(vtable, element, rawTable.getWidth(), rawTable.getHeight());
         assistLogic.loadFont(vtable, element);
         return vtable;
     }

--- a/src/org/dbflute/erflute/editor/persistent/xml/writer/WrittenDiagramWalkerBuilder.java
+++ b/src/org/dbflute/erflute/editor/persistent/xml/writer/WrittenDiagramWalkerBuilder.java
@@ -162,8 +162,8 @@ public class WrittenDiagramWalkerBuilder {
         final StringBuilder xml = new StringBuilder();
         // #for_erflute unneeded ID for connection
         //xml.append("<id>").append(context.connectionMap.get(connection)).append("</id>\n");
-        final String sourceId = context.walkerMap.get(connection.getWalkerSource());
-        final String targetId = context.walkerMap.get(connection.getWalkerTarget());
+        final String sourceId = context.walkerMap.get(connection.getSourceWalker());
+        final String targetId = context.walkerMap.get(connection.getTargetWalker());
         xml.append("<source>").append(sourceId != null ? sourceId : "$$owner$$").append("</source>\n"); // e.g. MEMBER_STATUS
         xml.append("<target>").append(targetId).append("</target>\n"); // e.g. MEMBER
         for (final Bendpoint bendpoint : connection.getBendpoints()) {

--- a/src/org/dbflute/erflute/editor/view/action/dbexport/ExportToImageAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/dbexport/ExportToImageAction.java
@@ -42,7 +42,7 @@ public class ExportToImageAction extends AbstractExportAction {
 
     public ExportToImageAction(MainDiagramEditor editor) {
         super(ID, DisplayMessages.getMessage("action.title.export.image"), editor);
-        this.setImageDescriptor(Activator.getImageDescriptor(ImageKey.EXPORT_TO_IMAGE));
+        setImageDescriptor(Activator.getImageDescriptor(ImageKey.EXPORT_TO_IMAGE));
     }
 
     @Override
@@ -60,7 +60,7 @@ public class ExportToImageAction extends AbstractExportAction {
         // return;
         // }
         // }
-        this.save(this.getEditorPart(), this.getGraphicalViewer());
+        save(getEditorPart(), getGraphicalViewer());
     }
 
     @Override
@@ -239,7 +239,7 @@ public class ExportToImageAction extends AbstractExportAction {
 
             for (final DiagramWalker sourceElement : visibleElements.keySet()) {
                 for (final WalkerConnection connection : sourceElement.getOutgoings()) {
-                    if (visibleElements.containsKey(connection.getWalkerTarget())) {
+                    if (visibleElements.containsKey(connection.getTargetWalker())) {
                         for (final Bendpoint bendpoint : connection.getBendpoints()) {
                             int x = bendpoint.getX();
                             int y = bendpoint.getY();

--- a/src/org/dbflute/erflute/editor/view/action/dbimport/ImportFromFileAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/dbimport/ImportFromFileAction.java
@@ -62,26 +62,23 @@ public class ImportFromFileAction extends AbstractImportAction {
 
     public ImportFromFileAction(MainDiagramEditor editor) {
         super(ID, DisplayMessages.getMessage("action.title.import.file"), editor);
-        this.setImageDescriptor(Activator.getImageDescriptor(ImageKey.TABLE));
+        setImageDescriptor(Activator.getImageDescriptor(ImageKey.TABLE));
     }
 
     protected DBObjectSet preImport() throws Exception {
-        String fileName = this.getLoadFilePath(this.getEditorPart());
+        final String fileName = getLoadFilePath(getEditorPart());
         if (fileName == null) {
             return null;
         }
 
-        Persistent persistent = Persistent.getInstance();
-
-        Path path = new Path(fileName);
-
+        final Persistent persistent = Persistent.getInstance();
+        final Path path = new Path(fileName);
         InputStream in = null;
-
         try {
-            IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
+            final IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
 
             if (file == null || !file.exists()) {
-                File realFile = path.toFile();
+                final File realFile = path.toFile();
                 if (realFile == null || !realFile.exists()) {
                     Activator.showErrorDialog("error.import.file");
                     return null;
@@ -98,31 +95,29 @@ public class ImportFromFileAction extends AbstractImportAction {
             }
 
             this.loadedDiagram = persistent.read(in);
-
         } finally {
             in.close();
         }
 
-        return this.getAllObjects(loadedDiagram);
+        return getAllObjects(loadedDiagram);
     }
 
     protected AbstractSelectImportedObjectDialog createSelectImportedObjectDialog(DBObjectSet dbObjectSet) {
-        ERDiagram diagram = this.getDiagram();
+        final ERDiagram diagram = getDiagram();
 
-        return new SelectImportedObjectFromFileDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), diagram, dbObjectSet);
+        return new SelectImportedObjectFromFileDialog(
+                PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+                diagram, dbObjectSet);
     }
 
     protected String getLoadFilePath(IEditorPart editorPart) {
-
-        IFile file = ((IFileEditorInput) editorPart.getEditorInput()).getFile();
-
-        FileDialog fileDialog = new FileDialog(editorPart.getEditorSite().getShell(), SWT.OPEN);
-
-        IProject project = file.getProject();
+        final IFile file = ((IFileEditorInput) editorPart.getEditorInput()).getFile();
+        final FileDialog fileDialog = new FileDialog(editorPart.getEditorSite().getShell(), SWT.OPEN);
+        final IProject project = file.getProject();
 
         fileDialog.setFilterPath(project.getLocation().toString());
 
-        String[] filterExtensions = this.getFilterExtensions();
+        final String[] filterExtensions = getFilterExtensions();
         fileDialog.setFilterExtensions(filterExtensions);
 
         return fileDialog.open();
@@ -133,16 +128,16 @@ public class ImportFromFileAction extends AbstractImportAction {
     }
 
     private DBObjectSet getAllObjects(ERDiagram loadedDiagram) {
-        DBObjectSet dbObjects = new DBObjectSet();
+        final DBObjectSet dbObjects = new DBObjectSet();
 
-        for (ERTable table : loadedDiagram.getDiagramContents().getDiagramWalkers().getTableSet()) {
-            DBObject dbObject = new DBObject(table.getTableViewProperties().getSchema(), table.getName(), DBObject.TYPE_TABLE);
+        for (final ERTable table : loadedDiagram.getDiagramContents().getDiagramWalkers().getTableSet()) {
+            final DBObject dbObject = new DBObject(table.getTableViewProperties().getSchema(), table.getName(), DBObject.TYPE_TABLE);
             dbObject.setModel(table);
             dbObjects.add(dbObject);
         }
 
-        for (ERView view : loadedDiagram.getDiagramContents().getDiagramWalkers().getViewSet()) {
-            DBObject dbObject = new DBObject(view.getTableViewProperties().getSchema(), view.getName(), DBObject.TYPE_VIEW);
+        for (final ERView view : loadedDiagram.getDiagramContents().getDiagramWalkers().getViewSet()) {
+            final DBObject dbObject = new DBObject(view.getTableViewProperties().getSchema(), view.getName(), DBObject.TYPE_VIEW);
             dbObject.setModel(view);
             dbObjects.add(dbObject);
         }
@@ -155,26 +150,26 @@ public class ImportFromFileAction extends AbstractImportAction {
         //			dbObjects.add(dbObject);
         //		}
 
-        for (Sequence sequence : loadedDiagram.getDiagramContents().getSequenceSet()) {
-            DBObject dbObject = new DBObject(sequence.getSchema(), sequence.getName(), DBObject.TYPE_SEQUENCE);
+        for (final Sequence sequence : loadedDiagram.getDiagramContents().getSequenceSet()) {
+            final DBObject dbObject = new DBObject(sequence.getSchema(), sequence.getName(), DBObject.TYPE_SEQUENCE);
             dbObject.setModel(sequence);
             dbObjects.add(dbObject);
         }
 
-        for (Trigger trigger : loadedDiagram.getDiagramContents().getTriggerSet()) {
-            DBObject dbObject = new DBObject(trigger.getSchema(), trigger.getName(), DBObject.TYPE_TRIGGER);
+        for (final Trigger trigger : loadedDiagram.getDiagramContents().getTriggerSet()) {
+            final DBObject dbObject = new DBObject(trigger.getSchema(), trigger.getName(), DBObject.TYPE_TRIGGER);
             dbObject.setModel(trigger);
             dbObjects.add(dbObject);
         }
 
-        for (Tablespace tablespace : loadedDiagram.getDiagramContents().getTablespaceSet()) {
-            DBObject dbObject = new DBObject(null, tablespace.getName(), DBObject.TYPE_TABLESPACE);
+        for (final Tablespace tablespace : loadedDiagram.getDiagramContents().getTablespaceSet()) {
+            final DBObject dbObject = new DBObject(null, tablespace.getName(), DBObject.TYPE_TABLESPACE);
             dbObject.setModel(tablespace);
             dbObjects.add(dbObject);
         }
 
-        for (ColumnGroup columnGroup : loadedDiagram.getDiagramContents().getColumnGroupSet()) {
-            DBObject dbObject = new DBObject(null, columnGroup.getName(), DBObject.TYPE_GROUP);
+        for (final ColumnGroup columnGroup : loadedDiagram.getDiagramContents().getColumnGroupSet()) {
+            final DBObject dbObject = new DBObject(null, columnGroup.getName(), DBObject.TYPE_GROUP);
             dbObject.setModel(columnGroup);
             dbObjects.add(dbObject);
         }
@@ -183,18 +178,15 @@ public class ImportFromFileAction extends AbstractImportAction {
     }
 
     protected void loadData(List<DBObject> selectedObjectList, boolean useCommentAsLogicalName, boolean mergeWord, boolean mergeGroup) {
-
-        Set<AbstractModel> selectedSets = new HashSet<AbstractModel>();
-        for (DBObject dbObject : selectedObjectList) {
+        final Set<AbstractModel> selectedSets = new HashSet<>();
+        for (final DBObject dbObject : selectedObjectList) {
             selectedSets.add(dbObject.getModel());
         }
 
-        DiagramContents contents = loadedDiagram.getDiagramContents();
-
-        ColumnGroupSet columnGroupSet = contents.getColumnGroupSet();
-
-        for (Iterator<ColumnGroup> iter = columnGroupSet.iterator(); iter.hasNext();) {
-            ColumnGroup columnGroup = iter.next();
+        final DiagramContents contents = loadedDiagram.getDiagramContents();
+        final ColumnGroupSet columnGroupSet = contents.getColumnGroupSet();
+        for (final Iterator<ColumnGroup> iter = columnGroupSet.iterator(); iter.hasNext();) {
+            final ColumnGroup columnGroup = iter.next();
 
             if (!selectedSets.contains(columnGroup)) {
                 iter.remove();
@@ -203,10 +195,9 @@ public class ImportFromFileAction extends AbstractImportAction {
 
         this.importedColumnGroups = columnGroupSet.getGroupList();
 
-        SequenceSet sequenceSet = contents.getSequenceSet();
-
-        for (Iterator<Sequence> iter = sequenceSet.iterator(); iter.hasNext();) {
-            Sequence sequence = iter.next();
+        final SequenceSet sequenceSet = contents.getSequenceSet();
+        for (final Iterator<Sequence> iter = sequenceSet.iterator(); iter.hasNext();) {
+            final Sequence sequence = iter.next();
 
             if (!selectedSets.contains(sequence)) {
                 iter.remove();
@@ -215,10 +206,9 @@ public class ImportFromFileAction extends AbstractImportAction {
 
         this.importedSequences = sequenceSet.getSequenceList();
 
-        TriggerSet triggerSet = contents.getTriggerSet();
-
-        for (Iterator<Trigger> iter = triggerSet.iterator(); iter.hasNext();) {
-            Trigger trigger = iter.next();
+        final TriggerSet triggerSet = contents.getTriggerSet();
+        for (final Iterator<Trigger> iter = triggerSet.iterator(); iter.hasNext();) {
+            final Trigger trigger = iter.next();
 
             if (!selectedSets.contains(trigger)) {
                 iter.remove();
@@ -227,10 +217,9 @@ public class ImportFromFileAction extends AbstractImportAction {
 
         this.importedTriggers = triggerSet.getTriggerList();
 
-        TablespaceSet tablespaceSet = contents.getTablespaceSet();
-
-        for (Iterator<Tablespace> iter = tablespaceSet.iterator(); iter.hasNext();) {
-            Tablespace tablespace = iter.next();
+        final TablespaceSet tablespaceSet = contents.getTablespaceSet();
+        for (final Iterator<Tablespace> iter = tablespaceSet.iterator(); iter.hasNext();) {
+            final Tablespace tablespace = iter.next();
 
             if (!selectedSets.contains(tablespace)) {
                 iter.remove();
@@ -239,37 +228,33 @@ public class ImportFromFileAction extends AbstractImportAction {
 
         this.importedTablespaces = tablespaceSet.getTablespaceList();
 
-        DiagramWalkerSet nodeSet = contents.getDiagramWalkers();
-        List<DiagramWalker> nodeElementList = nodeSet.getDiagramWalkerList();
-
-        for (Iterator<DiagramWalker> iter = nodeElementList.iterator(); iter.hasNext();) {
-            DiagramWalker nodeElement = iter.next();
+        final DiagramWalkerSet nodeSet = contents.getDiagramWalkers();
+        final List<DiagramWalker> nodeElementList = nodeSet.getDiagramWalkerList();
+        for (final Iterator<DiagramWalker> iter = nodeElementList.iterator(); iter.hasNext();) {
+            final DiagramWalker nodeElement = iter.next();
 
             if (!selectedSets.contains(nodeElement)) {
                 iter.remove();
             }
         }
 
-        DiagramWalkerSet selectedNodeSet = new DiagramWalkerSet();
-
-        Map<UniqueWord, Word> dictionary = new HashMap<UniqueWord, Word>();
-
+        final DiagramWalkerSet selectedNodeSet = new DiagramWalkerSet();
+        final Map<UniqueWord, Word> dictionary = new HashMap<>();
         if (mergeWord) {
-            for (Word word : this.getDiagram().getDiagramContents().getDictionary().getWordList()) {
+            for (final Word word : getDiagram().getDiagramContents().getDictionary().getWordList()) {
                 dictionary.put(new UniqueWord(word), word);
             }
         }
 
-        for (DiagramWalker nodeElement : nodeElementList) {
+        for (final DiagramWalker nodeElement : nodeElementList) {
             if (mergeWord) {
                 if (nodeElement instanceof TableView) {
-                    TableView tableView = (TableView) nodeElement;
-
-                    for (NormalColumn normalColumn : tableView.getNormalColumns()) {
-                        Word word = normalColumn.getWord();
+                    final TableView tableView = (TableView) nodeElement;
+                    for (final NormalColumn normalColumn : tableView.getNormalColumns()) {
+                        final Word word = normalColumn.getWord();
                         if (word != null) {
-                            UniqueWord uniqueWord = new UniqueWord(word);
-                            Word replaceWord = dictionary.get(uniqueWord);
+                            final UniqueWord uniqueWord = new UniqueWord(word);
+                            final Word replaceWord = dictionary.get(uniqueWord);
 
                             if (replaceWord != null) {
                                 normalColumn.setWord(replaceWord);
@@ -279,18 +264,17 @@ public class ImportFromFileAction extends AbstractImportAction {
                 }
             }
 
-            selectedNodeSet.addDiagramWalker(nodeElement);
+            selectedNodeSet.add(nodeElement);
         }
 
-        for (DiagramWalker nodeElement : selectedNodeSet) {
+        for (final DiagramWalker nodeElement : selectedNodeSet) {
             if (nodeElement instanceof TableView) {
-                TableView tableView = (TableView) nodeElement;
-
-                for (Iterator<ERColumn> iter = tableView.getColumns().iterator(); iter.hasNext();) {
-                    ERColumn column = iter.next();
+                final TableView tableView = (TableView) nodeElement;
+                for (final Iterator<ERColumn> iter = tableView.getColumns().iterator(); iter.hasNext();) {
+                    final ERColumn column = iter.next();
 
                     if (column instanceof ColumnGroup) {
-                        if (!this.importedColumnGroups.contains(column)) {
+                        if (!importedColumnGroups.contains(column)) {
                             iter.remove();
                         }
                     }
@@ -299,23 +283,21 @@ public class ImportFromFileAction extends AbstractImportAction {
         }
 
         if (mergeGroup) {
-            Map<String, ColumnGroup> groupMap = new HashMap<String, ColumnGroup>();
+            final Map<String, ColumnGroup> groupMap = new HashMap<>();
 
-            for (ColumnGroup columnGroup : this.getDiagram().getDiagramContents().getColumnGroupSet()) {
+            for (final ColumnGroup columnGroup : getDiagram().getDiagramContents().getColumnGroupSet()) {
                 groupMap.put(columnGroup.getGroupName(), columnGroup);
             }
 
-            for (Iterator<ColumnGroup> iter = this.importedColumnGroups.iterator(); iter.hasNext();) {
-                ColumnGroup columnGroup = iter.next();
-
-                ColumnGroup replaceColumnGroup = groupMap.get(columnGroup.getGroupName());
-
+            for (final Iterator<ColumnGroup> iter = importedColumnGroups.iterator(); iter.hasNext();) {
+                final ColumnGroup columnGroup = iter.next();
+                final ColumnGroup replaceColumnGroup = groupMap.get(columnGroup.getGroupName());
                 if (replaceColumnGroup != null) {
                     iter.remove();
 
-                    for (DiagramWalker nodeElement : selectedNodeSet) {
+                    for (final DiagramWalker nodeElement : selectedNodeSet) {
                         if (nodeElement instanceof TableView) {
-                            TableView tableView = (TableView) nodeElement;
+                            final TableView tableView = (TableView) nodeElement;
                             tableView.replaceColumnGroup(columnGroup, replaceColumnGroup);
                         }
                     }
@@ -323,28 +305,25 @@ public class ImportFromFileAction extends AbstractImportAction {
             }
         }
 
-        CopyManager copyManager = new CopyManager();
-        DiagramWalkerSet copyList = copyManager.copyNodeElementList(selectedNodeSet);
+        final CopyManager copyManager = new CopyManager();
+        final DiagramWalkerSet copyList = copyManager.copyNodeElementList(selectedNodeSet);
 
         this.importedNodeElements = copyList.getDiagramWalkerList();
     }
 
     @Override
     public void execute(Event event) throws Exception {
-        DBObjectSet dbObjectSet = this.preImport();
+        final DBObjectSet dbObjectSet = preImport();
 
         if (dbObjectSet != null) {
-            AbstractSelectImportedObjectDialog importDialog = this.createSelectImportedObjectDialog(dbObjectSet);
-
-            int result = importDialog.open();
-
+            final AbstractSelectImportedObjectDialog importDialog = createSelectImportedObjectDialog(dbObjectSet);
+            final int result = importDialog.open();
             if (result == IDialogConstants.OK_ID) {
-                this.loadData(importDialog.getSelectedDbObjects(), importDialog.isUseCommentAsLogicalName(), importDialog.isMergeWord(),
-                        importDialog.isMergeGroup());
-                this.showData();
-
+                loadData(importDialog.getSelectedDbObjects(), importDialog.isUseCommentAsLogicalName(),
+                        importDialog.isMergeWord(), importDialog.isMergeGroup());
+                showData();
             } else if (result == IDialogConstants.BACK_ID) {
-                this.execute(event);
+                execute(event);
             }
         }
     }

--- a/src/org/dbflute/erflute/editor/view/action/edit/CopyAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/edit/CopyAction.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 import org.dbflute.erflute.core.DisplayMessages;
 import org.dbflute.erflute.editor.controller.editpart.element.ERDiagramEditPart;
-import org.dbflute.erflute.editor.controller.editpart.element.node.ModelPropertiesEditPart;
 import org.dbflute.erflute.editor.controller.editpart.element.node.DiagramWalkerEditPart;
+import org.dbflute.erflute.editor.controller.editpart.element.node.ModelPropertiesEditPart;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalker;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.DiagramWalkerSet;
 import org.dbflute.erflute.editor.model.edit.CopyManager;
@@ -28,13 +28,13 @@ public class CopyAction extends SelectionAction {
         final ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();
         setImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_COPY));
         setDisabledImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_COPY_DISABLED));
-        this.setId(ActionFactory.COPY.getId());
+        setId(ActionFactory.COPY.getId());
     }
 
     @Override
     @SuppressWarnings("unchecked")
     protected boolean calculateEnabled() {
-        final List<EditPart> list = new ArrayList<EditPart>(this.getSelectedObjects());
+        final List<EditPart> list = new ArrayList<EditPart>(getSelectedObjects());
         if (list.isEmpty()) {
             return false;
         }
@@ -59,7 +59,7 @@ public class CopyAction extends SelectionAction {
             if (object instanceof DiagramWalkerEditPart) {
                 final DiagramWalkerEditPart editPart = (DiagramWalkerEditPart) object;
                 final DiagramWalker nodeElement = (DiagramWalker) editPart.getModel();
-                nodeElementList.addDiagramWalker(nodeElement);
+                nodeElementList.add(nodeElement);
             }
         }
         CopyManager.copy(nodeElementList);

--- a/src/org/dbflute/erflute/editor/view/action/edit/PasteAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/edit/PasteAction.java
@@ -88,8 +88,9 @@ public class PasteAction extends SelectionAction {
             final ERDiagram diagram = (ERDiagram) model;
 
             final Command command =
-                    new PasteCommand(editor, pasteList, diagram.mousePoint.x - x + (numberOfCopy - 1) * 20, diagram.mousePoint.y - y
-                            + (numberOfCopy - 1) * 20);
+                    new PasteCommand(editor, pasteList,
+                            diagram.getMousePoint().x - x + (numberOfCopy - 1) * 20,
+                            diagram.getMousePoint().y - y + (numberOfCopy - 1) * 20);
 
             return command;
         }
@@ -99,7 +100,8 @@ public class PasteAction extends SelectionAction {
 
             // diagram.mousePointはメインダイアグラムのマウス座標を参照するため、使えない。
             final Command command =
-                    new PasteCommand(editor, pasteList, virtualDiagram.getMousePoint().x - x + (numberOfCopy - 1) * 20,
+                    new PasteCommand(editor, pasteList,
+                            virtualDiagram.getMousePoint().x - x + (numberOfCopy - 1) * 20,
                             virtualDiagram.getMousePoint().y - y + (numberOfCopy - 1) * 20);
 
             return command;

--- a/src/org/dbflute/erflute/editor/view/action/ermodel/PlaceTableAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/ermodel/PlaceTableAction.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.dbflute.erflute.editor.VirtualDiagramEditor;
 import org.dbflute.erflute.editor.model.ERDiagram;
-import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERVirtualTable;
 import org.dbflute.erflute.editor.view.action.AbstractBaseAction;
@@ -27,10 +26,9 @@ public class PlaceTableAction extends AbstractBaseAction {
 
     @Override
     public void execute(Event event) throws Exception {
-        final ERDiagram diagram = this.getDiagram();
-        final ERVirtualDiagram model = oneEditor.getVirtualDiagram();
+        final ERDiagram diagram = getDiagram();
 
-        final List<ERTable> input = new ArrayList<ERTable>();
+        final List<ERTable> input = new ArrayList<>();
         input.addAll(diagram.getDiagramContents().getDiagramWalkers().getTableSet().getList());
 
         final NodeSelectionDialog dialog =
@@ -45,14 +43,10 @@ public class PlaceTableAction extends AbstractBaseAction {
             final Object[] results = dialog.getResult();
             for (final Object result : results) {
                 final ERTable curTable = (ERTable) result;
-                final ERVirtualTable virtualTable = new ERVirtualTable(model, curTable);
+                final ERVirtualTable virtualTable = new ERVirtualTable(oneEditor.getVirtualDiagram(), curTable);
                 virtualTable.setPoint(point.x, point.y);
-                model.addTable(virtualTable);
-                //				oneEditor.setContents(model);
-                //				oneEditor.refreshContents();
-                //				model.changeAll();
+                getDiagram().addWalkerPlainly(virtualTable);
             }
         }
-
     }
 }

--- a/src/org/dbflute/erflute/editor/view/action/ermodel/VirtualDiagramAddAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/ermodel/VirtualDiagramAddAction.java
@@ -21,7 +21,7 @@ public class VirtualDiagramAddAction extends AbstractBaseAction {
     public static final String ID = VirtualDiagramAddAction.class.getName();
 
     public VirtualDiagramAddAction(MainDiagramEditor editor) {
-        super(ID, "New VirtualDiagram", editor);
+        super(ID, "New Virtual Diagram", editor);
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/view/action/ermodel/VirtualDiagramAddAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/ermodel/VirtualDiagramAddAction.java
@@ -28,7 +28,7 @@ public class VirtualDiagramAddAction extends AbstractBaseAction {
     public void execute(Event event) throws Exception {
         final ERDiagram diagram = this.getDiagram();
         final Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-        final String dialogTitle = "New VirtualDiagram";
+        final String dialogTitle = "New Virtual Diagram";
         final String dialogMessage = "Input name for new Virtual Diagram";
         final InputVirtualDiagramNameValidator validator = new InputVirtualDiagramNameValidator(diagram, null);
         final InputDialog dialog = new InputDialog(shell, dialogTitle, dialogMessage, "", validator);

--- a/src/org/dbflute/erflute/editor/view/action/option/notation/ChangeTitleFontSizeAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/option/notation/ChangeTitleFontSizeAction.java
@@ -14,15 +14,13 @@ public class ChangeTitleFontSizeAction extends AbstractBaseAction {
 
     public ChangeTitleFontSizeAction(MainDiagramEditor editor) {
         super(ID, null, IAction.AS_CHECK_BOX, editor);
-        this.setText(DisplayMessages.getMessage("action.title.display.titleFontLarge"));
+        this.setText(DisplayMessages.getMessage("Display table title larger"));
     }
 
     @Override
     public void execute(Event event) {
-        ERDiagram diagram = this.getDiagram();
-
-        ChangeTitleFontSizeCommand command = new ChangeTitleFontSizeCommand(diagram, this.isChecked());
-
+        final ERDiagram diagram = this.getDiagram();
+        final ChangeTitleFontSizeCommand command = new ChangeTitleFontSizeCommand(diagram, this.isChecked());
         this.execute(command);
     }
 }

--- a/src/org/dbflute/erflute/editor/view/action/outline/ChangeNameAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/outline/ChangeNameAction.java
@@ -26,7 +26,6 @@ public class ChangeNameAction extends AbstractOutlineBaseAction {
 
     @Override
     public void execute(Event event) {
-
         final ERDiagram diagram = this.getDiagram();
 
         final List selectedEditParts = this.getTreeViewer().getSelectedEditParts();
@@ -35,12 +34,13 @@ public class ChangeNameAction extends AbstractOutlineBaseAction {
         if (model instanceof ERVirtualDiagram) {
             final ERVirtualDiagram vdiagram = (ERVirtualDiagram) model;
             final InputVirtualDiagramNameValidator validator = new InputVirtualDiagramNameValidator(diagram, vdiagram.getName());
-            final InputDialog dialog =
-                    new InputDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Rename", "Input new name",
-                            vdiagram.getName(), validator);
+            final InputDialog dialog = new InputDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Rename",
+                    "Input new name", vdiagram.getName(), validator);
             if (dialog.open() == IDialogConstants.OK_ID) {
                 vdiagram.setName(dialog.getValue());
                 diagram.getDiagramContents().getVirtualDiagramSet().changeVdiagram(vdiagram);
+                // ここでsetDirtyしてるが多分無駄。
+                // ファイル編集中にしたかったら、コマンド化してコマンドスタックに積んで実行しないと無理そう。
                 vdiagram.getDiagram().getEditor().setDirty(true);
                 //				ermodel.changeAll();
                 //				AddERModelCommand command = new AddERModelCommand(diagram, dialog.getValue());

--- a/src/org/dbflute/erflute/editor/view/action/outline/ChangeNameAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/outline/ChangeNameAction.java
@@ -2,6 +2,7 @@ package org.dbflute.erflute.editor.view.action.outline;
 
 import java.util.List;
 
+import org.dbflute.erflute.editor.controller.command.ermodel.ChangeVirtualDiagramNameCommand;
 import org.dbflute.erflute.editor.model.ERDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
 import org.dbflute.erflute.editor.view.dialog.vdiagram.InputVirtualDiagramNameValidator;
@@ -27,7 +28,6 @@ public class ChangeNameAction extends AbstractOutlineBaseAction {
     @Override
     public void execute(Event event) {
         final ERDiagram diagram = this.getDiagram();
-
         final List selectedEditParts = this.getTreeViewer().getSelectedEditParts();
         final EditPart editPart = (EditPart) selectedEditParts.get(0);
         final Object model = editPart.getModel();
@@ -37,14 +37,8 @@ public class ChangeNameAction extends AbstractOutlineBaseAction {
             final InputDialog dialog = new InputDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Rename",
                     "Input new name", vdiagram.getName(), validator);
             if (dialog.open() == IDialogConstants.OK_ID) {
-                vdiagram.setName(dialog.getValue());
-                diagram.getDiagramContents().getVirtualDiagramSet().changeVdiagram(vdiagram);
-                // TODO ここでsetDirtyしてるが多分無駄。
-                // ファイル編集中にしたかったら、コマンド化してコマンドスタックに積んで実行しないと無理そう。
-                vdiagram.getDiagram().getEditor().setDirty(true);
-                //				ermodel.changeAll();
-                //				AddERModelCommand command = new AddERModelCommand(diagram, dialog.getValue());
-                //				this.execute(command);
+                final ChangeVirtualDiagramNameCommand command = new ChangeVirtualDiagramNameCommand(vdiagram, dialog.getValue());
+                this.execute(command);
             }
         }
     }

--- a/src/org/dbflute/erflute/editor/view/action/outline/ChangeNameAction.java
+++ b/src/org/dbflute/erflute/editor/view/action/outline/ChangeNameAction.java
@@ -39,7 +39,7 @@ public class ChangeNameAction extends AbstractOutlineBaseAction {
             if (dialog.open() == IDialogConstants.OK_ID) {
                 vdiagram.setName(dialog.getValue());
                 diagram.getDiagramContents().getVirtualDiagramSet().changeVdiagram(vdiagram);
-                // ここでsetDirtyしてるが多分無駄。
+                // TODO ここでsetDirtyしてるが多分無駄。
                 // ファイル編集中にしたかったら、コマンド化してコマンドスタックに積んで実行しないと無理そう。
                 vdiagram.getDiagram().getEditor().setDirty(true);
                 //				ermodel.changeAll();

--- a/src/org/dbflute/erflute/editor/view/dialog/option/tab/OptionTabWrapper.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/option/tab/OptionTabWrapper.java
@@ -53,7 +53,15 @@ public class OptionTabWrapper extends ValidatableTabWrapper {
         final GridLayout innerLayout = new GridLayout();
         innerLayout.numColumns = 3;
         innerComp.setLayout(innerLayout);
-        CompositeFactory.createLabel(innerComp, "???"); // #willanalyze what is this? by jflute
+        /*
+         * #willanalyze what is this? by jflute
+         *
+         * modified by ymd
+         * 下記ラベルのテキストは、文字化けしていて解読できなかった。
+         * ERMaster-bを起動して確認したところ「マスタデータ基準ディレクトリ」となっていた。
+         * これをそのまま翻訳して修正した。これがどんな機能かは調べていない。
+         */
+        CompositeFactory.createLabel(innerComp, "Master data reference directory");
         this.outputFileText = new InnerDirectoryText(innerComp, SWT.BORDER);
         final GridData gridData = new GridData();
         gridData.widthHint = 200;

--- a/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
@@ -388,7 +388,7 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
         if (isCreateNewColumn()) {
             // TODO ymd コマンド外の操作でカラムを追加しているため、undoしてもカラムが削除されない。コマンド化する。
             for (final NormalColumn referredColumn : selectedReferredColumnList) {
-                final NormalColumn newColumn = new NormalColumn(referredColumn, resultReferenceForPK);
+                final NormalColumn newColumn = createForeignKeyColumn(referredColumn, newCreatedRelationship, resultReferenceForPK);
                 adjustNewForeignKeyColumn(newColumn);
                 selectedForeignKeyColumnList.add(newColumn);
                 target.addColumn(newColumn);
@@ -402,6 +402,10 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
 
     private Relationship createRelationship() {
         return new Relationship(resultReferenceForPK, resultReferredComplexUniqueKey, resultReferredSimpleUniqueColumn);
+    }
+
+    private NormalColumn createForeignKeyColumn(NormalColumn referredColumn, Relationship relationship, boolean referenceForPK) {
+        return new NormalColumn(referredColumn, referredColumn, relationship, referenceForPK);
     }
 
     private void adjustNewForeignKeyColumn(NormalColumn newColumn) {

--- a/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
@@ -386,8 +386,9 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
         newCreatedRelationship = createRelationship();
         newCreatedRelationship.setForeignKeyName(foreignKeyNameText.getText().trim());
         if (isCreateNewColumn()) {
+            // TODO コマンド外の操作でカラムを追加しているため、undoしてもカラムが削除されない。
             for (final NormalColumn referredColumn : selectedReferredColumnList) {
-                final NormalColumn newColumn = createForeignKeyColumn(referredColumn, newCreatedRelationship, resultReferenceForPK);
+                final NormalColumn newColumn = new NormalColumn(referredColumn, resultReferenceForPK);
                 adjustNewForeignKeyColumn(newColumn);
                 selectedForeignKeyColumnList.add(newColumn);
                 target.addColumn(newColumn);
@@ -401,10 +402,6 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
 
     private Relationship createRelationship() {
         return new Relationship(resultReferenceForPK, resultReferredComplexUniqueKey, resultReferredSimpleUniqueColumn);
-    }
-
-    private NormalColumn createForeignKeyColumn(NormalColumn referredColumn, Relationship relationship, boolean referenceForPK) {
-        return new NormalColumn(referredColumn, referredColumn, relationship, referenceForPK);
     }
 
     private void adjustNewForeignKeyColumn(NormalColumn newColumn) {

--- a/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
@@ -386,7 +386,7 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
         newCreatedRelationship = createRelationship();
         newCreatedRelationship.setForeignKeyName(foreignKeyNameText.getText().trim());
         if (isCreateNewColumn()) {
-            // TODO コマンド外の操作でカラムを追加しているため、undoしてもカラムが削除されない。
+            // TODO ymd コマンド外の操作でカラムを追加しているため、undoしてもカラムが削除されない。コマンド化する。
             for (final NormalColumn referredColumn : selectedReferredColumnList) {
                 final NormalColumn newColumn = new NormalColumn(referredColumn, resultReferenceForPK);
                 adjustNewForeignKeyColumn(newColumn);

--- a/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/relationship/RelationshipByExistingColumnsDialog.java
@@ -88,15 +88,15 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
         super(parentShell, 2);
         this.source = source;
         this.target = target;
-        this.selectedReferredColumnList = new ArrayList<NormalColumn>();
+        this.selectedReferredColumnList = new ArrayList<>();
         this.candidateForeignKeyColumns = candidateForeignKeyColumns;
         this.existingRootReferredToFkColumnsMap = existingRootReferredToFkColumnsMap;
         this.existingRelationshipToFkColumnsMap = existingRelationshipToFkColumnsMap;
 
-        this.mapperEditorList = new ArrayList<TableEditor>();
-        this.mapperEditorToReferredColumnsMap = new HashMap<TableEditor, List<NormalColumn>>();
+        this.mapperEditorList = new ArrayList<>();
+        this.mapperEditorToReferredColumnsMap = new HashMap<>();
 
-        this.selectedForeignKeyColumnList = new ArrayList<NormalColumn>();
+        this.selectedForeignKeyColumnList = new ArrayList<>();
     }
 
     // ===================================================================================
@@ -243,7 +243,7 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
             } else {
                 final NormalColumn referencedColumn =
                         referredColumnState.candidateColumns.get(referredColumnIndex - referredColumnState.columnStartIndex);
-                selectedReferredColumnList = new ArrayList<NormalColumn>();
+                selectedReferredColumnList = new ArrayList<>();
                 selectedReferredColumnList.add(referencedColumn);
             }
             for (final NormalColumn referredColumn : selectedReferredColumnList) {
@@ -318,7 +318,7 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
             return null;
         } else {
             // #hope check type difference by jflute
-            final Set<NormalColumn> selectedColumns = new HashSet<NormalColumn>();
+            final Set<NormalColumn> selectedColumns = new HashSet<>();
             for (final TableEditor tableEditor : mapperEditorList) {
                 final Combo foreignKeySelector = (Combo) tableEditor.getEditor();
                 final int selectionIndex = foreignKeySelector.getSelectionIndex();
@@ -387,7 +387,7 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
         newCreatedRelationship.setForeignKeyName(foreignKeyNameText.getText().trim());
         if (isCreateNewColumn()) {
             for (final NormalColumn referredColumn : selectedReferredColumnList) {
-                final NormalColumn newColumn = newForeignKeyColumn(referredColumn, newCreatedRelationship, resultReferenceForPK);
+                final NormalColumn newColumn = createForeignKeyColumn(referredColumn, newCreatedRelationship, resultReferenceForPK);
                 adjustNewForeignKeyColumn(newColumn);
                 selectedForeignKeyColumnList.add(newColumn);
                 target.addColumn(newColumn);
@@ -403,7 +403,7 @@ public class RelationshipByExistingColumnsDialog extends AbstractDialog {
         return new Relationship(resultReferenceForPK, resultReferredComplexUniqueKey, resultReferredSimpleUniqueColumn);
     }
 
-    private NormalColumn newForeignKeyColumn(NormalColumn referredColumn, Relationship relationship, boolean referenceForPK) {
+    private NormalColumn createForeignKeyColumn(NormalColumn referredColumn, Relationship relationship, boolean referenceForPK) {
         return new NormalColumn(referredColumn, referredColumn, relationship, referenceForPK);
     }
 

--- a/src/org/dbflute/erflute/editor/view/dialog/table/tab/ConstraintTabWrapper.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/table/tab/ConstraintTabWrapper.java
@@ -25,53 +25,51 @@ public class ConstraintTabWrapper extends ValidatableTabWrapper {
         this.copyData = copyData;
         this.tableDialog = tableDialog;
 
-        this.init();
+        init();
     }
 
     @Override
     public void validatePage() throws InputException {
         String text = constraintText.getText().trim();
-        this.copyData.setConstraint(text);
+        copyData.setConstraint(text);
 
         text = primaryKeyNameText.getText().trim();
-        if (!Check.isAlphabet(text)) {
+        if (copyData.getDiagramSettings().isValidatePhysicalName() && !Check.isAlphabet(text)) {
             throw new InputException("error.primary.key.name.not.alphabet");
         }
-        this.copyData.setPrimaryKeyName(text);
+        copyData.setPrimaryKeyName(text);
 
         text = optionText.getText().trim();
-        this.copyData.setOption(text);
+        copyData.setOption(text);
     }
 
     @Override
     public void initComposite() {
         final GridLayout gridLayout = new GridLayout();
         gridLayout.numColumns = 1;
-        this.setLayout(gridLayout);
+        setLayout(gridLayout);
 
         CompositeFactory.createLabel(this, "label.table.constraint", 1);
 
         this.constraintText = CompositeFactory.createTextArea(tableDialog, this, null, -1, 100, 1, false);
-
-        this.constraintText.setText(Format.null2blank(copyData.getConstraint()));
+        constraintText.setText(Format.null2blank(copyData.getConstraint()));
 
         CompositeFactory.filler(this, 1);
 
         this.primaryKeyNameText = CompositeFactory.createText(tableDialog, this, "label.primary.key.name", 1, false);
-        this.primaryKeyNameText.setText(Format.null2blank(copyData.getPrimaryKeyName()));
+        primaryKeyNameText.setText(Format.null2blank(copyData.getPrimaryKeyName()));
 
         CompositeFactory.filler(this, 1);
 
         CompositeFactory.createLabel(this, "label.option", 1);
 
         this.optionText = CompositeFactory.createTextArea(tableDialog, this, null, -1, 100, 1, false);
-
-        this.optionText.setText(Format.null2blank(copyData.getOption()));
+        optionText.setText(Format.null2blank(copyData.getOption()));
     }
 
     @Override
     public void setInitFocus() {
-        this.constraintText.setFocus();
+        constraintText.setFocus();
     }
 
     @Override

--- a/src/org/dbflute/erflute/editor/view/drag_drop/ERDiagramTransferDragSourceListener.java
+++ b/src/org/dbflute/erflute/editor/view/drag_drop/ERDiagramTransferDragSourceListener.java
@@ -14,23 +14,18 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.dnd.AbstractTransferDragSourceListener;
 import org.eclipse.gef.dnd.TemplateTransfer;
+import org.eclipse.gef.ui.parts.ScrollingGraphicalViewer;
 import org.eclipse.swt.dnd.DragSourceEvent;
 import org.eclipse.swt.dnd.Transfer;
 
 public class ERDiagramTransferDragSourceListener extends AbstractTransferDragSourceListener {
 
     public static final String REQUEST_TYPE_MOVE_COLUMN = "move column";
-
     public static final String REQUEST_TYPE_MOVE_COLUMN_GROUP = "move column group";
-
     public static final String REQUEST_TYPE_ADD_COLUMN_GROUP = "add column group";
-
     public static final String MOVE_COLUMN_GROUP_PARAM_PARENT = "parent";
-
     public static final String MOVE_COLUMN_GROUP_PARAM_GROUP = "group";
-
     public static final String REQUEST_TYPE_ADD_WORD = "add word";
-
     public static final String REQUEST_TYPE_PLACE_TABLE = "place table";
 
     private final EditPartViewer dragSourceViewer;
@@ -45,15 +40,13 @@ public class ERDiagramTransferDragSourceListener extends AbstractTransferDragSou
     public void dragStart(DragSourceEvent dragsourceevent) {
         super.dragStart(dragsourceevent);
 
-        final Object target = this.getTargetModel(dragsourceevent);
-
+        final Object target = getTargetModel(dragsourceevent);
         if (target != null) {
             // && target == dragSourceViewer.findObjectAt(
             // new Point(dragsourceevent.x, dragsourceevent.y))
             // .getModel()) {
-            final TemplateTransfer transfer = (TemplateTransfer) this.getTransfer();
+            final TemplateTransfer transfer = (TemplateTransfer) getTransfer();
             transfer.setObject(target);
-
         } else {
             dragsourceevent.doit = false;
         }
@@ -68,7 +61,7 @@ public class ERDiagramTransferDragSourceListener extends AbstractTransferDragSou
 
     @Override
     public void dragSetData(DragSourceEvent event) {
-        event.data = this.getTargetModel(event);
+        event.data = getTargetModel(event);
     }
 
     private Object getTargetModel(DragSourceEvent event) {
@@ -76,6 +69,7 @@ public class ERDiagramTransferDragSourceListener extends AbstractTransferDragSou
         if (editParts.isEmpty()) {
             return null;
         }
+
         if (editParts.size() != 1) {
             final List<Object> results = new ArrayList<>();
             for (final Object partObj : editParts) {
@@ -85,37 +79,33 @@ public class ERDiagramTransferDragSourceListener extends AbstractTransferDragSou
                     // アウトラインからのテーブル複数選択
                     results.add(model);
                 }
-                if (model instanceof ERTable) {
+
+                if (model instanceof ERTable && getViewer() instanceof ScrollingGraphicalViewer) {
                     // エディタ内からの実テーブルおよび仮想テーブル複数選択
                     return null; // ここはドラッグはせず、上位の移動機構（？）に回す。これで複数テーブルをエディタ内で移動可能になる
                 }
             }
+
             return results;
         }
 
         final EditPart editPart = (EditPart) editParts.get(0);
-
         final Object model = editPart.getModel();
-
         if (model instanceof NormalColumn) {
             final NormalColumn normalColumn = (NormalColumn) model;
             if (normalColumn.getColumnHolder() instanceof ColumnGroup) {
                 final Map<String, Object> map = new HashMap<>();
                 map.put(MOVE_COLUMN_GROUP_PARAM_PARENT, editPart.getParent().getModel());
                 map.put(MOVE_COLUMN_GROUP_PARAM_GROUP, normalColumn.getColumnHolder());
-
                 return map;
             }
 
             return model;
-
         } else if (model instanceof ColumnGroup) {
             final Map<String, Object> map = new HashMap<>();
             map.put(MOVE_COLUMN_GROUP_PARAM_PARENT, editPart.getParent().getModel());
             map.put(MOVE_COLUMN_GROUP_PARAM_GROUP, model);
-
             return map;
-
         } else if (model instanceof Word) {
             return model;
         } else if (model instanceof ERTable && editPart instanceof TableOutlineEditPart) {

--- a/src/org/dbflute/erflute/editor/view/figure/connection/ERDiagramConnection.java
+++ b/src/org/dbflute/erflute/editor/view/figure/connection/ERDiagramConnection.java
@@ -14,11 +14,9 @@ import org.eclipse.swt.widgets.Display;
 public class ERDiagramConnection extends PolylineConnection {
 
     private static final double DELTA = 0.01;
-
     private static final int TOLERANCE = 2;
 
     private boolean selected;
-
     private boolean bezier;
 
     public ERDiagramConnection(boolean bezier) {
@@ -40,11 +38,11 @@ public class ERDiagramConnection extends PolylineConnection {
         g.setForegroundColor(ColorConstants.black);
         g.setLineWidth(1);
 
-        if (this.selected) {
-            if (this.bezier) {
+        if (selected) {
+            if (bezier) {
                 g.setForegroundColor(ColorConstants.gray);
 
-                PointList points = getPoints();
+                final PointList points = getPoints();
                 g.drawPolyline(points);
             }
 
@@ -52,19 +50,19 @@ public class ERDiagramConnection extends PolylineConnection {
             g.setLineWidth(7);
         }
 
-        PointList points = getBezierPoints();
+        final PointList points = getBezierPoints();
 
         int width = g.getLineWidth();
 
         Color color = g.getForegroundColor();
 
-        int lineRed = color.getRed();
-        int lineGreen = color.getGreen();
-        int lineBlue = color.getBlue();
+        final int lineRed = color.getRed();
+        final int lineGreen = color.getGreen();
+        final int lineBlue = color.getBlue();
 
-        int deltaRed = (255 - lineRed) * 2 / width;
-        int deltaGreen = (255 - lineGreen) * 2 / width;
-        int deltaBlue = (255 - lineBlue) * 2 / width;
+        final int deltaRed = (255 - lineRed) * 2 / width;
+        final int deltaGreen = (255 - lineGreen) * 2 / width;
+        final int deltaBlue = (255 - lineBlue) * 2 / width;
 
         int red = 255;
         int green = 255;
@@ -96,12 +94,12 @@ public class ERDiagramConnection extends PolylineConnection {
     }
 
     public PointList getBezierPoints() {
-        PointList controlPoints = this.getPoints();
+        final PointList controlPoints = getPoints();
 
-        if (this.bezier && controlPoints.size() >= 3) {
+        if (bezier && controlPoints.size() >= 3) {
             int index = 0;
 
-            PointList pointList = new PointList();
+            final PointList pointList = new PointList();
 
             Point p0 = controlPoints.getPoint(index++);
             Point p1 = controlPoints.getPoint(index++);
@@ -117,7 +115,7 @@ public class ERDiagramConnection extends PolylineConnection {
                 }
 
                 for (double t = 0.0; t <= 1.0; t = t + DELTA) {
-                    Point point = new Point();
+                    final Point point = new Point();
 
                     point.x = (int) (p0.x * (1 - t) * (1 - t) + 2 * p1.x * t * (1 - t) + p2.x * t * t);
 
@@ -145,6 +143,6 @@ public class ERDiagramConnection extends PolylineConnection {
 
     @Override
     protected boolean shapeContainsPoint(int x, int y) {
-        return Geometry.polylineContainsPoint(this.getBezierPoints(), x, y, TOLERANCE);
+        return Geometry.polylineContainsPoint(getBezierPoints(), x, y, TOLERANCE);
     }
 }

--- a/src/org/dbflute/erflute/editor/view/information/ERDiagramInformationControl.java
+++ b/src/org/dbflute/erflute/editor/view/information/ERDiagramInformationControl.java
@@ -34,7 +34,7 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
 
     private ERDiagramOutlinePage outline;
     private Text search;
-    private ERDiagram diagram;
+    private final ERDiagram diagram;
 
     public ERDiagramInformationControl(ERDiagram diagram, Shell shell, Control composite) {
         super(shell, true);
@@ -42,14 +42,14 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
 
         create();
 
-        int width = 300;
-        int height = 300;
+        final int width = 300;
+        final int height = 300;
 
-        Point loc = composite.toDisplay(0, 0);
-        Point size = composite.getSize();
+        final Point loc = composite.toDisplay(0, 0);
+        final Point size = composite.getSize();
 
-        int x = (size.x - width) / 2 + loc.x;
-        int y = (size.y - height) / 2 + loc.y;
+        final int x = (size.x - width) / 2 + loc.x;
+        final int y = (size.y - height) / 2 + loc.y;
 
         setSize(width, height);
         setLocation(new Point(x, y));
@@ -63,10 +63,10 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
 
     @Override
     protected void createContent(Composite parent) {
-        Color foreground = parent.getShell().getDisplay().getSystemColor(SWT.COLOR_INFO_FOREGROUND);
-        Color background = parent.getShell().getDisplay().getSystemColor(SWT.COLOR_INFO_BACKGROUND);
+        final Color foreground = parent.getShell().getDisplay().getSystemColor(SWT.COLOR_INFO_FOREGROUND);
+        final Color background = parent.getShell().getDisplay().getSystemColor(SWT.COLOR_INFO_BACKGROUND);
 
-        Composite composite = new Composite(parent, SWT.NULL);
+        final Composite composite = new Composite(parent, SWT.NULL);
         composite.setLayout(new GridLayout(1, false));
         composite.setForeground(foreground);
         composite.setBackground(background);
@@ -82,8 +82,9 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
 
         search.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         search.addModifyListener(new ModifyListener() {
+            @Override
             public void modifyText(ModifyEvent e) {
-                String filterText = search.getText();
+                final String filterText = search.getText();
                 outline.setFilterText(filterText);
             }
         });
@@ -102,20 +103,20 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
             }
         });
 
-        Composite treeArea = new Composite(composite, SWT.NULL);
+        final Composite treeArea = new Composite(composite, SWT.NULL);
         treeArea.setLayout(new FillLayout());
         treeArea.setLayoutData(new GridData(GridData.FILL_BOTH));
 
         outline = new ERDiagramOutlinePage(diagram);
         outline.setQuickMode(true);
 
-        IEditorPart activeEditor = ((ERFluteMultiPageEditor) ERModelUtil.getActiveEditor()).getActiveEditor();
+        final IEditorPart activeEditor = ((ERFluteMultiPageEditor) ERModelUtil.getActiveEditor()).getActiveEditor();
         if (activeEditor instanceof VirtualDiagramEditor) {
-            VirtualDiagramEditor editor = (VirtualDiagramEditor) activeEditor;
-            outline.setCategory(editor.getDefaultEditDomain(), editor.getGraphicalViewer(), null, editor.getDefaultActionRegistry());
+            final VirtualDiagramEditor editor = (VirtualDiagramEditor) activeEditor;
+            outline.setCategory(editor.getDefaultEditDomain(), editor.getGraphicalViewer(), editor.getDefaultActionRegistry());
         } else {
-            MainDiagramEditor editor = (MainDiagramEditor) activeEditor;
-            outline.setCategory(editor.getDefaultEditDomain(), editor.getGraphicalViewer(), null, editor.getDefaultActionRegistry());
+            final MainDiagramEditor editor = (MainDiagramEditor) activeEditor;
+            outline.setCategory(editor.getDefaultEditDomain(), editor.getGraphicalViewer(), editor.getDefaultActionRegistry());
         }
 
         outline.createControl(treeArea);
@@ -136,8 +137,8 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
             }
         });
 
-        TreeViewer treeViewer = (TreeViewer) outline.getViewer();
-        Tree tree = (Tree) treeViewer.getControl();
+        final TreeViewer treeViewer = (TreeViewer) outline.getViewer();
+        final Tree tree = (Tree) treeViewer.getControl();
         expand(tree.getItems());
 
         //		outline.getViewer().addDoubleClickListener(new IDoubleClickListener() {
@@ -165,6 +166,7 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
         search.setFocus();
     }
 
+    @Override
     public boolean hasContents() {
         return true;
     }

--- a/src/org/dbflute/erflute/editor/view/information/ERDiagramInformationControl.java
+++ b/src/org/dbflute/erflute/editor/view/information/ERDiagramInformationControl.java
@@ -16,6 +16,8 @@ import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.FillLayout;
@@ -132,6 +134,15 @@ public class ERDiagramInformationControl extends AbstractInformationControl {
             @Override
             public void keyReleased(KeyEvent e) {
                 if (e.keyCode == SWT.CR) {
+                    selectAndDispose();
+                }
+            }
+        });
+        outline.getViewer().getControl().addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseUp(MouseEvent e) {
+                final int TABLE_SELECTION_BUTTON = 3;
+                if (e.button == TABLE_SELECTION_BUTTON) {
                     selectAndDispose();
                 }
             }

--- a/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
+++ b/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
@@ -1,15 +1,11 @@
 package org.dbflute.erflute.editor.view.outline;
 
-import java.util.List;
-
 import org.dbflute.erflute.Activator;
 import org.dbflute.erflute.editor.MainDiagramEditor;
 import org.dbflute.erflute.editor.controller.command.ermodel.OpenERModelCommand;
 import org.dbflute.erflute.editor.controller.editpart.outline.ERDiagramOutlineEditPart;
 import org.dbflute.erflute.editor.controller.editpart.outline.ERDiagramOutlineEditPartFactory;
 import org.dbflute.erflute.editor.controller.editpart.outline.table.TableOutlineEditPart;
-import org.dbflute.erflute.editor.controller.editpart.outline.vdiagram.ERVirtualDiagramOutlineEditPart;
-import org.dbflute.erflute.editor.controller.editpart.outline.vdiagram.ERVirtualDiagramSetOutlineEditPart;
 import org.dbflute.erflute.editor.model.ERDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.ermodel.ERVirtualDiagram;
 import org.dbflute.erflute.editor.model.diagram_contents.element.node.table.ERTable;
@@ -42,9 +38,7 @@ import org.eclipse.gef.ui.parts.ContentOutlinePage;
 import org.eclipse.gef.ui.parts.TreeViewer;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
-import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.widgets.Canvas;
@@ -259,20 +253,21 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
                 command.setTable(table);
                 command.execute(); // コマンドスタックには積まないで実行する。ファイル編集中にしないため。
 
-                final ERDiagramOutlineEditPart contents =
-                        (ERDiagramOutlineEditPart) diagram.getEditor().getOutlinePage().getViewer().getContents();
-                if (contents != null) {
-                    final ERVirtualDiagramSetOutlineEditPart virtualDiagramSetOutlineEditPart =
-                            (ERVirtualDiagramSetOutlineEditPart) contents.getChildren().get(0);
-                    @SuppressWarnings("unchecked")
-                    final List<ERVirtualDiagramOutlineEditPart> parts = virtualDiagramSetOutlineEditPart.getChildren();
-                    for (final ERVirtualDiagramOutlineEditPart part : parts) {
-                        if (part.getModel().equals(erModel)) {
-                            final ISelection selection = new StructuredSelection(part);
-                            diagram.getEditor().getOutlinePage().setSelection(selection);
-                        }
-                    }
-                }
+                // TODO ymd アウトラインツリー上の仮想ダイアグラムを選択するためにのみある。
+                //                final ERDiagramOutlineEditPart contents =
+                //                        (ERDiagramOutlineEditPart) diagram.getEditor().getOutlinePage().getViewer().getContents();
+                //                if (contents != null) {
+                //                    final ERVirtualDiagramSetOutlineEditPart virtualDiagramSetOutlineEditPart =
+                //                            (ERVirtualDiagramSetOutlineEditPart) contents.getChildren().get(0);
+                //                    @SuppressWarnings("unchecked")
+                //                    final List<ERVirtualDiagramOutlineEditPart> parts = virtualDiagramSetOutlineEditPart.getChildren();
+                //                    for (final ERVirtualDiagramOutlineEditPart part : parts) {
+                //                        if (part.getModel().equals(erModel)) {
+                //                            final ISelection selection = new StructuredSelection(part);
+                //                            diagram.getEditor().getOutlinePage().setSelection(selection);
+                //                        }
+                //                    }
+                //                }
             } else {
                 Activator.showMessageDialog(table.getPhysicalName());
             }

--- a/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
+++ b/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
@@ -73,28 +73,28 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
 
     public ERDiagramOutlinePage(ERDiagram diagram) {
         super(new TreeViewer());
-        this.viewer = (TreeViewer) this.getViewer();
+        this.viewer = (TreeViewer) getViewer();
         this.diagram = diagram;
         this.outlineActionRegistory = new ActionRegistry();
-        this.registerAction(this.viewer, outlineActionRegistory);
+        registerAction(viewer, outlineActionRegistory);
     }
 
     @Override
     public void createControl(Composite parent) {
         this.sash = new SashForm(parent, SWT.VERTICAL);
-        this.viewer.createControl(this.sash);
+        this.viewer.createControl(sash);
         editPartFactory = new ERDiagramOutlineEditPartFactory();
         editPartFactory.setQuickMode(quickMode);
-        this.viewer.setEditPartFactory(editPartFactory);
-        this.viewer.setContents(this.diagram);
+        viewer.setEditPartFactory(editPartFactory);
+        viewer.setContents(diagram);
         if (!quickMode) {
-            final Canvas canvas = new Canvas(this.sash, SWT.BORDER);
+            final Canvas canvas = new Canvas(sash, SWT.BORDER);
             this.lws = new LightweightSystem(canvas);
         }
-        this.resetView(this.registry);
+        resetView(registry);
         final AbstractTransferDragSourceListener dragSourceListener =
-                new ERDiagramTransferDragSourceListener(this.viewer, TemplateTransfer.getInstance());
-        this.viewer.addDragSourceListener(dragSourceListener);
+                new ERDiagramTransferDragSourceListener(viewer, TemplateTransfer.getInstance());
+        viewer.addDragSourceListener(dragSourceListener);
     }
 
     @Override
@@ -106,33 +106,33 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
         if (quickMode) {
             return;
         }
-        final ScalableFreeformRootEditPart editPart = (ScalableFreeformRootEditPart) this.graphicalViewer.getRootEditPart();
-        if (this.thumbnail != null) {
-            this.thumbnail.deactivate();
+        final ScalableFreeformRootEditPart editPart = (ScalableFreeformRootEditPart) graphicalViewer.getRootEditPart();
+        if (thumbnail != null) {
+            thumbnail.deactivate();
         }
         this.thumbnail = new ScrollableThumbnail((Viewport) editPart.getFigure());
-        this.thumbnail.setSource(editPart.getLayer(LayerConstants.PRINTABLE_LAYERS));
-        this.lws.setContents(this.thumbnail);
+        thumbnail.setSource(editPart.getLayer(LayerConstants.PRINTABLE_LAYERS));
+        lws.setContents(thumbnail);
     }
 
     private void initDropTarget() {
         final AbstractTransferDropTargetListener dropTargetListener =
-                new ERDiagramOutlineTransferDropTargetListener(this.graphicalViewer, TemplateTransfer.getInstance());
-        this.graphicalViewer.addDropTargetListener(dropTargetListener);
+                new ERDiagramOutlineTransferDropTargetListener(graphicalViewer, TemplateTransfer.getInstance());
+        graphicalViewer.addDropTargetListener(dropTargetListener);
     }
 
     public void setContextMenu(MenuManager outlineMenuMgr) {
-        this.viewer.setContextMenu(outlineMenuMgr);
+        viewer.setContextMenu(outlineMenuMgr);
     }
 
     public void setCategory(EditDomain editDomain, GraphicalViewer graphicalViewer, ActionRegistry registry) {
         this.graphicalViewer = graphicalViewer;
 
-        this.viewer.setEditDomain(editDomain);
+        viewer.setEditDomain(editDomain);
         this.registry = registry;
 
-        if (this.getSite() != null) {
-            this.resetView(registry);
+        if (getSite() != null) {
+            resetView(registry);
         }
     }
 
@@ -140,7 +140,7 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
         if (getSite() == null) {
             return;
         }
-        final IActionBars bars = this.getSite().getActionBars();
+        final IActionBars bars = getSite().getActionBars();
 
         String id = ActionFactory.UNDO.getId();
         bars.setGlobalActionHandler(id, registry.getAction(id));
@@ -155,9 +155,9 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
     }
 
     private void resetView(ActionRegistry registry) {
-        this.showThumbnail();
-        this.initDropTarget();
-        this.resetAction(registry);
+        showThumbnail();
+        initDropTarget();
+        resetAction(registry);
     }
 
     private void registerAction(TreeViewer treeViewer, ActionRegistry actionRegistry) {
@@ -257,7 +257,7 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
             if (erModel != null) {
                 final OpenERModelCommand command = new OpenERModelCommand(diagram, erModel);
                 command.setTable(table);
-                this.getViewer().getEditDomain().getCommandStack().execute(command);
+                command.execute(); // コマンドスタックには積まないで実行する。ファイル編集中にしないため。
 
                 final ERDiagramOutlineEditPart contents =
                         (ERDiagramOutlineEditPart) diagram.getEditor().getOutlinePage().getViewer().getContents();

--- a/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
+++ b/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
@@ -121,9 +121,12 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
         this.graphicalViewer.addDropTargetListener(dropTargetListener);
     }
 
-    public void setCategory(EditDomain editDomain, GraphicalViewer graphicalViewer, MenuManager outlineMenuMgr, ActionRegistry registry) {
-        this.graphicalViewer = graphicalViewer;
+    public void setContextMenu(MenuManager outlineMenuMgr) {
         this.viewer.setContextMenu(outlineMenuMgr);
+    }
+
+    public void setCategory(EditDomain editDomain, GraphicalViewer graphicalViewer, ActionRegistry registry) {
+        this.graphicalViewer = graphicalViewer;
 
         this.viewer.setEditDomain(editDomain);
         this.registry = registry;
@@ -158,13 +161,12 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
     }
 
     private void registerAction(TreeViewer treeViewer, ActionRegistry actionRegistry) {
-        final IAction[] actions =
-                { new CreateIndexAction(treeViewer), new CreateSequenceAction(treeViewer), new CreateTriggerAction(treeViewer),
-                        new CreateTablespaceAction(treeViewer), new ChangeOutlineViewToPhysicalAction(treeViewer),
-                        new ChangeOutlineViewToLogicalAction(treeViewer), new ChangeOutlineViewToBothAction(treeViewer),
-                        new ChangeOutlineViewOrderByPhysicalNameAction(treeViewer),
-                        new ChangeOutlineViewOrderByLogicalNameAction(treeViewer), new ChangeNameAction(treeViewer),
-                        new DeleteVirtualDiagramAction(treeViewer), };
+        final IAction[] actions = { new CreateIndexAction(treeViewer), new CreateSequenceAction(treeViewer),
+                new CreateTriggerAction(treeViewer), new CreateTablespaceAction(treeViewer),
+                new ChangeOutlineViewToPhysicalAction(treeViewer), new ChangeOutlineViewToLogicalAction(treeViewer),
+                new ChangeOutlineViewToBothAction(treeViewer), new ChangeOutlineViewOrderByPhysicalNameAction(treeViewer),
+                new ChangeOutlineViewOrderByLogicalNameAction(treeViewer), new ChangeNameAction(treeViewer),
+                new DeleteVirtualDiagramAction(treeViewer), };
         for (final IAction action : actions) {
             actionRegistry.registerAction(action);
         }

--- a/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
+++ b/src/org/dbflute/erflute/editor/view/outline/ERDiagramOutlinePage.java
@@ -254,6 +254,7 @@ public class ERDiagramOutlinePage extends ContentOutlinePage {
                 command.execute(); // コマンドスタックには積まないで実行する。ファイル編集中にしないため。
 
                 // TODO ymd アウトラインツリー上の仮想ダイアグラムを選択するためにのみある。
+                // この処理があることで、クイックアウトライン検索→テーブル選択がバグるのでコメントにした。不要なことを確信したら、削除する。
                 //                final ERDiagramOutlineEditPart contents =
                 //                        (ERDiagramOutlineEditPart) diagram.getEditor().getOutlinePage().getViewer().getContents();
                 //                if (contents != null) {

--- a/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
+++ b/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
@@ -2,6 +2,8 @@ package org.dbflute.erflute.editor.view.tool;
 
 import java.util.List;
 
+import org.dbflute.erflute.editor.ERFluteMultiPageEditor;
+import org.dbflute.erflute.editor.MainDiagramEditor;
 import org.dbflute.erflute.editor.controller.command.diagram_contents.element.node.MoveElementCommand;
 import org.dbflute.erflute.editor.controller.editpart.element.ERDiagramEditPart;
 import org.dbflute.erflute.editor.controller.editpart.element.connection.RelationEditPart;
@@ -124,12 +126,16 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
 
     @Override
     public void mouseDown(MouseEvent e, EditPartViewer viewer) {
+        ERFluteMultiPageEditor multiPageEditor = null;
+
         // マウスポインタがクリックされた位置を記録する。コピーしたオブジェクトの貼り付け位置として使う、等。
         if (viewer.getContents() instanceof ERDiagramEditPart) {
             final ERDiagramEditPart editPart = (ERDiagramEditPart) viewer.getContents();
             final ERDiagram diagram = (ERDiagram) editPart.getModel();
             diagram.setMousePoint(new Point(e.x, e.y));
             editPart.getFigure().translateToRelative(diagram.getMousePoint());
+
+            multiPageEditor = diagram.getEditor();
         }
 
         if (viewer.getContents() instanceof ERVirtualDiagramEditPart) {
@@ -137,6 +143,14 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
             final ERVirtualDiagram diagram = (ERVirtualDiagram) editPart.getModel();
             diagram.setMousePoint(new Point(e.x, e.y));
             editPart.getFigure().translateToRelative(diagram.getMousePoint());
+
+            multiPageEditor = diagram.getDiagram().getEditor();
+        }
+
+        final int QUICK_OUTLINE_OPEN_BUTTON = 2;
+        if (e.button == QUICK_OUTLINE_OPEN_BUTTON && multiPageEditor != null) {
+            final MainDiagramEditor mainDiagramEditor = (MainDiagramEditor) multiPageEditor.getActiveEditor();
+            mainDiagramEditor.runERDiagramQuickOutlineAction();
         }
 
         super.mouseDown(e, viewer);

--- a/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
+++ b/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
@@ -56,8 +56,11 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
             dx = 1;
         } else if (event.keyCode == SWT.ARROW_UP) {
             dy = -1;
+        } else if (event.keyCode == SWT.CTRL) {
+            return false;
         }
-        final Object model = this.getCurrentViewer().getContents().getModel();
+
+        final Object model = getCurrentViewer().getContents().getModel();
         AbstractGraphicalEditPart targetEditPart = null;
         ERDiagram diagram = null;
         if (model instanceof ERVirtualDiagram) {
@@ -87,7 +90,9 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
                 getCurrentViewer().getEditDomain().getCommandStack().execute(command.unwrap());
             }
         }
+
         openDetailByKeyCode(event, targetEditPart);
+
         return super.handleKeyDown(event);
     }
 

--- a/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
+++ b/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
@@ -118,6 +118,7 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
 
     @Override
     public void mouseDown(MouseEvent e, EditPartViewer viewer) {
+        // マウスポインタがクリックされた位置を記録する。コピーしたオブジェクトの貼り付け位置として使う、等。
         if (viewer.getContents() instanceof ERDiagramEditPart) {
             final ERDiagramEditPart editPart = (ERDiagramEditPart) viewer.getContents();
             final ERDiagram diagram = (ERDiagram) editPart.getModel();

--- a/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
+++ b/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
@@ -96,8 +96,8 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
                 || obj instanceof ModelPropertiesEditPart;
     }
 
-    private MoveElementCommand createMoveElementCommand(int dx, int dy, ERDiagram diagram, final DiagramWalkerEditPart editPart,
-            final DiagramWalker nodeElement) {
+    private MoveElementCommand createMoveElementCommand(int dx, int dy, ERDiagram diagram,
+            final DiagramWalkerEditPart editPart, final DiagramWalker nodeElement) {
         final Rectangle bounds = editPart.getFigure().getBounds();
         final int width = nodeElement.getWidth();
         final int height = nodeElement.getHeight();
@@ -121,8 +121,8 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
         if (viewer.getContents() instanceof ERDiagramEditPart) {
             final ERDiagramEditPart editPart = (ERDiagramEditPart) viewer.getContents();
             final ERDiagram diagram = (ERDiagram) editPart.getModel();
-            diagram.mousePoint = new Point(e.x, e.y);
-            editPart.getFigure().translateToRelative(diagram.mousePoint);
+            diagram.setMousePoint(new Point(e.x, e.y));
+            editPart.getFigure().translateToRelative(diagram.getMousePoint());
         }
 
         if (viewer.getContents() instanceof ERVirtualDiagramEditPart) {

--- a/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
+++ b/src/org/dbflute/erflute/editor/view/tool/MovablePanningSelectionTool.java
@@ -47,6 +47,7 @@ public class MovablePanningSelectionTool extends PanningSelectionTool {
         int dy = 0;
         if (event.keyCode == SWT.SHIFT) {
             shift = true;
+            return false;
         }
         if (event.keyCode == SWT.ARROW_DOWN) {
             dy = 1;


### PR DESCRIPTION
## 修正した問題
- 仮想ダイアグラムでFK列自動生成機能を使っても、FK列が自動生成されない。
- FK削除で自動生成されたFK列が残ってしまう。
- 仮想ダイアグラムを開いただけでタブに変更マークが付く。
- "仮想ダイアグラムを開く→メインダイアグラムを開く"を行った後、アウトラインで、右クリックコンテキストメニューが表示されない。(ファイルを開き直すと直る)
- 仮想ダイアグラムでテーブルをコピー後、コピー先テーブルの名前とカラム名を変更すると、コピー元のカラム名も変更されてしまう。
- 仮想ダイアグラムでテーブルのサイズを変更しても反映されない。
- 表示中の仮想ダイアグラム名を変更しても、エディタのタブに反映されない。(仮想ダイアグラムを開き直すと反映)
- 仮想ダイアグラム名を変更しても、ファイル編集中にならない。
- 仮想ダイアグラムを開いても、開いた仮想ダイアグラムがアウトラインのツリー上で選択されないことがある。
- 仮想ダイアグラムでリレーションシップの接続線を移動できない。
- コンテキストメニューなどの表記がおかしい。
- 仮想ダイアグラムでテーブル削除をundoすると例外が発生する。(undo自体は成功している。しかし、仮想ダイアグラムを開き直さないと再描画されない。これはメインダイアグラムでも同じ。)
- ノートの削除をundoできない。
- 仮想ダイアグラムでテーブルを削除するとリレーションシップが残る。(仮想ダイアグラムを開き直すと直る)
- 外部キー列が重複して追加される問題を修正した。
- 仮想ダイアグラムで自己関連を作成できない。
- テーブルやノートを選択してCtrlキーやShiftキーを押すとファイル編集中になる。

## 前回プルリクで出したバグの修正
- アウトラインから仮想ダイアグラムを複数選択してドラッグアンドドロップできない。
- 主キー列が外部キー列でもあるテーブルを参照する外部キーを、新規列作成有りで作成するとエラーが発生する。

## 追加した機能
- "JDBC Driver Class"が見つからない時のエラーメッセージを追加した。
- アウトライン検索して見つかったテーブルを選択状態にする。
- マウスの中クリックでクイックアウトラインを開く。
- マウスのスクロールボタンクリックでクイックアウトラインを表示する。
- クイックアウトライン上でテーブルを右クリックすると、メイン、仮想ダイアグラム上でテーブルが選択状態になる。

## 特記すべき変更
- Materializable<T>インターフェースを追加し、DiagramWalkerで実装した。仮想(ERVirtualTable等)と実体(ERTable等)を透過的に扱うために使用する。
- ワーカー間の接続線のリフレッシュ方法を変更した。ソースとターゲットが両方存在する場合のみ、表示するように変更した。
- コピペ時に接続線を貼り付け対象外とした。リレーションシップやノートの接続線をコピーすると、描画がバグったり例外が発生するため。大して便利でないと思ったので。