### PR TITLE
Bug fix related to column group name change

### DIFF
--- a/src/org/dbflute/erflute/editor/view/dialog/columngroup/ColumnGroupDialog.java
+++ b/src/org/dbflute/erflute/editor/view/dialog/columngroup/ColumnGroupDialog.java
@@ -89,7 +89,11 @@ public class ColumnGroupDialog extends AbstractDialog implements ERTableComposit
             return;
         }
 
-        copyColumnGroups.get(0).setGroupName(groupNameText.getText());
+        if (editTargetIndex == -1) {
+            copyColumnGroups.get(0).setGroupName(groupNameText.getText());
+        } else {
+            copyColumnGroups.get(editTargetIndex).setGroupName(groupNameText.getText());
+        }
     }
 
     public List<CopyColumnGroup> getCopyColumnGroups() {


### PR DESCRIPTION
アウトラインツリー上のカラムグループノードを、ダブルクリックして表示したダイアログで名前変更を行うと、必ず一番上のノード名が変更される不具合を修正しました。