### PR TITLE
Replace H2DBManager with H2EclipseDBManager

### DIFF
--- a/src/org/dbflute/erflute/db/EclipseDBManagerFactory.java
+++ b/src/org/dbflute/erflute/db/EclipseDBManagerFactory.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.dbflute.erflute.core.DisplayMessages;
 import org.dbflute.erflute.db.impl.access.AccessEclipseDBManager;
 import org.dbflute.erflute.db.impl.db2.DB2EclipseDBManager;
-import org.dbflute.erflute.db.impl.h2.H2DBManager;
+import org.dbflute.erflute.db.impl.h2.H2EclipseDBManager;
 import org.dbflute.erflute.db.impl.hsqldb.HSQLDBEclipseDBManager;
 import org.dbflute.erflute.db.impl.mysql.MySQLEclipseDBManager;
 import org.dbflute.erflute.db.impl.oracle.OracleEclipseDBManager;
@@ -24,7 +24,7 @@ public class EclipseDBManagerFactory {
     static {
         new StandardSQLEclipseDBManager();
         new DB2EclipseDBManager();
-        new H2DBManager();
+        new H2EclipseDBManager();
         new HSQLDBEclipseDBManager();
         new AccessEclipseDBManager();
         new MySQLEclipseDBManager();


### PR DESCRIPTION
**Problem**

- **What I did**: Create a new erm file, select "H2", add a table and double-click it to open.
- **What happend**: IllegalArgumentException "Database is not supported :H2"

**Cause**

H2EclipseDBManager is not registered; H2DBManager is instantiated instead.

**Fix**

Replaced H2DBManager with H2EclipseDBManager.

Just replacing the instantiation fixes the problem, but I would rather code like:
```
    static {
        addDB(new StandardSQLEclipseDBManager());
        addDB(new DB2EclipseDBManager());
        addDB(new H2EclipseDBManager());
        // ...
```
so that Java's type checker could find the bug.