### PR TITLE
Add installation instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-ERFlute
-=======================
+# ERFlute
+
 ERD Modeling Tool for Startup & Incremental Development as Eclipse Plugin
 
 ## Features
@@ -10,22 +10,52 @@ ERD Modeling Tool for Startup & Incremental Development as Eclipse Plugin
 
 ## Install ERFlute
 
-```
-dropins
- |-ERFlute
-    |-eclipse
-       |-plugins
-          |-org.dbflute.erflute_0.5.8.jar
-```
+See [Download jar](http://dbflute.seasar.org/ja/manual/function/helper/erflute/index.html#downloadjar)
 
 ## License
+
 Apache License 2.0
 
 ## Official site
+
 Japanese Official site  
 http://dbflute.seasar.org/ja/manual/function/helper/erflute/index.html
 
+## Contribution to ERFlute
+
+### Installation
+
+1. Use the LTS JDK (11 or 17)
+1. Download the latest eclipse from https://mergedoc.osdn.jp/
+   Standard Edition is enough.
+   Since there are many unnecessary features for plugin development, there is no need to use Full Edition for Eclipse plugin development.
+
+### Clone
+
+1. Fork and clone this repository
+1. Import the repository to your eclipse workspace
+
+### Develop
+
+1. Make feature branch from develop
+
+### Test
+
+1. Open plugin.xml in Plug-in Manifest Editor
+1. Click Test -> Launch an Eclipse application
+1. Test ERFlute at eclipse
+
+### Make Pull Request
+
+1. Push your branch
+1. Make pull request to `erflute:develop`.
+
+### Structures
+
+See [README_ja.txt](./README_ja.txt).
+
 # Thanks, Frameworks
-ERFlute forks ERMaster, ERMaster-b.  
+
+ERFlute forks ERMaster, ERMaster-b.
 
 I appreciate every framework.


### PR DESCRIPTION
# 対応したこと

直近で開発環境を作ったので開発環境構築の手順を書いてみました。#3 で長年要望にもありましたので。

VSCodeでフォーマットがかかっていますので、関係ない分の変更も出ています。

Macは下記で動作しました。lastaflute-example-harborのER図が開けました

- macOS Monterey
- AdoptOpenJDK 11
- eclipse 2021-12 (最新) for Mac Standard Edition https://mergedoc.osdn.jp/

ハードやメモリは動作にあまり関係ないと思いますが、MacBook Pro 2019年モデル(CPUはIntel)です。M1 Macでは動作確認できていません。

# その他
コンパイル環境の最新化も必要だと思います。対応はしていません。

http://dbflute.seasar.org/ja/manual/function/helper/erflute/index.html